### PR TITLE
Add customer profile view, more fields, editing support

### DIFF
--- a/src/app/account.tsx
+++ b/src/app/account.tsx
@@ -1,24 +1,458 @@
-import { Link } from "expo-router";
+import { Link, type Href } from "expo-router";
 import { useState } from "react";
 import {
   ActivityIndicator,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
+  TextInput,
   View,
 } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
-import { AuthScreenShell } from "../components/auth-screen-shell";
+import { type PreferredContactMethod, type UserProfile } from "../lib/profiles";
 import { useAuth } from "../providers/auth-provider";
 
+type CustomerProfileDraft = {
+  displayName: string;
+  fullName: string;
+  phoneNumber: string;
+  locationLabel: string;
+  preferredContactMethod: PreferredContactMethod;
+  bio: string;
+  defaultPickupNotes: string;
+};
+
+const contactMethodOptions: {
+  value: PreferredContactMethod;
+  title: string;
+  body: string;
+}[] = [
+  {
+    value: "email",
+    title: "Email",
+    body: "Best for reminders, order updates, and routine communication.",
+  },
+  {
+    value: "phone",
+    title: "Phone",
+    body: "Useful when pickup details change at short notice.",
+  },
+];
+
+function formatTimestamp(value: string | null | undefined) {
+  if (!value) {
+    return "Unavailable";
+  }
+
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    return "Unavailable";
+  }
+
+  return parsed.toLocaleString("en-GB", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function createCustomerDraft(
+  profile: UserProfile | null,
+): CustomerProfileDraft {
+  return {
+    displayName: profile?.displayName ?? profile?.fullName ?? "",
+    fullName: profile?.fullName ?? "",
+    phoneNumber: profile?.phoneNumber ?? "",
+    locationLabel: profile?.locationLabel ?? "",
+    preferredContactMethod: profile?.preferredContactMethod ?? "email",
+    bio: profile?.bio ?? "",
+    defaultPickupNotes: profile?.defaultPickupNotes ?? "",
+  };
+}
+
+function AccountMetaCard({
+  email,
+  role,
+  createdAt,
+  updatedAt,
+}: {
+  email: string | null | undefined;
+  role: string | null | undefined;
+  createdAt: string | null | undefined;
+  updatedAt: string | null | undefined;
+}) {
+  return (
+    <View style={styles.panel}>
+      <Text style={styles.panelTitle}>Account details</Text>
+      <View style={styles.readonlyGrid}>
+        <View style={styles.readonlyItem}>
+          <Text style={styles.readonlyLabel}>Email</Text>
+          <Text style={styles.readonlyValue}>{email ?? "Unknown email"}</Text>
+        </View>
+        <View style={styles.readonlyItem}>
+          <Text style={styles.readonlyLabel}>Account type</Text>
+          <Text style={styles.readonlyValue}>
+            {role === "farmer" ? "Farmer" : "Customer"}
+          </Text>
+        </View>
+        <View style={styles.readonlyItem}>
+          <Text style={styles.readonlyLabel}>Account created</Text>
+          <Text style={styles.readonlyMeta}>{formatTimestamp(createdAt)}</Text>
+        </View>
+        <View style={styles.readonlyItem}>
+          <Text style={styles.readonlyLabel}>Last updated</Text>
+          <Text style={styles.readonlyMeta}>{formatTimestamp(updatedAt)}</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function ProfileHeader({ profile }: { profile: UserProfile | null }) {
+  const title = profile?.displayName ?? profile?.fullName ?? "Your profile";
+  const isFarmer = profile?.role === "farmer";
+  const subtitle = isFarmer
+    ? "Farmer profiles will get their own editing flow in a later pass."
+    : (profile?.locationLabel ??
+      "Set a display name, contact preference, and pickup notes.");
+
+  return (
+    <View style={styles.heroCard}>
+      <View style={styles.avatarCircle}>
+        <Text style={styles.avatarText}>
+          {title
+            .split(" ")
+            .slice(0, 2)
+            .map((part) => part.charAt(0).toUpperCase())
+            .join("") || "FC"}
+        </Text>
+      </View>
+      <View style={styles.heroCopy}>
+        <Text style={styles.eyebrow}>
+          {isFarmer ? "Farmer profile" : "Customer profile"}
+        </Text>
+        <Text style={styles.heroTitle}>{title}</Text>
+        <Text style={styles.heroBody}>{subtitle}</Text>
+      </View>
+    </View>
+  );
+}
+
+function CustomerProfileView({
+  draft,
+  isEditing,
+  loading,
+  onCancel,
+  onEdit,
+  onSave,
+  onChange,
+}: {
+  draft: CustomerProfileDraft;
+  isEditing: boolean;
+  loading: boolean;
+  onCancel: () => void;
+  onEdit: () => void;
+  onSave: () => void;
+  onChange: <K extends keyof CustomerProfileDraft>(
+    key: K,
+    value: CustomerProfileDraft[K],
+  ) => void;
+}) {
+  if (!isEditing) {
+    return (
+      <View style={styles.panel}>
+        <View style={styles.sectionHeader}>
+          <View style={styles.sectionCopy}>
+            <Text style={styles.panelTitle}>Customer profile</Text>
+            <Text style={styles.panelBody}>
+              This profile is shown as a customer account and stores the
+              personal details that matter for reservations and pickup
+              coordination.
+            </Text>
+          </View>
+          <Pressable
+            accessibilityRole="button"
+            onPress={onEdit}
+            style={styles.inlineButton}
+            testID="edit-profile-button"
+          >
+            <Text style={styles.inlineButtonText}>Edit customer profile</Text>
+          </Pressable>
+        </View>
+
+        <View style={styles.readonlyGrid}>
+          <View style={styles.readonlyItem}>
+            <Text style={styles.readonlyLabel}>Display name</Text>
+            <Text style={styles.readonlyValue}>
+              {draft.displayName || "Not set"}
+            </Text>
+          </View>
+          <View style={styles.readonlyItem}>
+            <Text style={styles.readonlyLabel}>Full name</Text>
+            <Text style={styles.readonlyValue}>
+              {draft.fullName || "Not set"}
+            </Text>
+          </View>
+          <View style={styles.readonlyItem}>
+            <Text style={styles.readonlyLabel}>Phone number</Text>
+            <Text style={styles.readonlyValue}>
+              {draft.phoneNumber || "Not set"}
+            </Text>
+          </View>
+          <View style={styles.readonlyItem}>
+            <Text style={styles.readonlyLabel}>Location</Text>
+            <Text style={styles.readonlyValue}>
+              {draft.locationLabel || "Not set"}
+            </Text>
+          </View>
+          <View style={styles.readonlyItem}>
+            <Text style={styles.readonlyLabel}>Preferred contact</Text>
+            <Text style={styles.readonlyValue}>
+              {draft.preferredContactMethod === "phone" ? "Phone" : "Email"}
+            </Text>
+          </View>
+        </View>
+
+        <View style={styles.textBlock}>
+          <Text style={styles.readonlyLabel}>Bio</Text>
+          <Text style={styles.longValue}>
+            {draft.bio || "No bio added yet."}
+          </Text>
+        </View>
+        <View style={styles.textBlock}>
+          <Text style={styles.readonlyLabel}>Pickup notes</Text>
+          <Text style={styles.longValue}>
+            {draft.defaultPickupNotes || "No pickup notes saved yet."}
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.panel}>
+      <Text style={styles.panelTitle}>Edit customer profile</Text>
+      <Text style={styles.panelBody}>
+        Keep this focused on the details a farm needs when preparing a
+        reservation for you.
+      </Text>
+
+      <View style={styles.formGrid}>
+        <View style={styles.fieldGroup}>
+          <Text style={styles.label}>Display name</Text>
+          <TextInput
+            onChangeText={(value) => onChange("displayName", value)}
+            placeholder="How you want to appear in the app"
+            placeholderTextColor="#7A867D"
+            style={styles.input}
+            value={draft.displayName}
+          />
+        </View>
+        <View style={styles.fieldGroup}>
+          <Text style={styles.label}>Full name</Text>
+          <TextInput
+            onChangeText={(value) => onChange("fullName", value)}
+            placeholder="Your full name"
+            placeholderTextColor="#7A867D"
+            style={styles.input}
+            value={draft.fullName}
+          />
+        </View>
+        <View style={styles.fieldGroup}>
+          <Text style={styles.label}>Phone number</Text>
+          <TextInput
+            keyboardType="phone-pad"
+            onChangeText={(value) => onChange("phoneNumber", value)}
+            placeholder="Optional phone number"
+            placeholderTextColor="#7A867D"
+            style={styles.input}
+            value={draft.phoneNumber}
+          />
+        </View>
+        <View style={styles.fieldGroup}>
+          <Text style={styles.label}>Location</Text>
+          <TextInput
+            onChangeText={(value) => onChange("locationLabel", value)}
+            placeholder="Town, village, or area"
+            placeholderTextColor="#7A867D"
+            style={styles.input}
+            value={draft.locationLabel}
+          />
+        </View>
+      </View>
+
+      <View style={styles.fieldGroup}>
+        <Text style={styles.label}>Preferred contact method</Text>
+        <View style={styles.optionGrid}>
+          {contactMethodOptions.map((option) => {
+            const active = draft.preferredContactMethod === option.value;
+
+            return (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityState={{ selected: active }}
+                key={option.value}
+                onPress={() => onChange("preferredContactMethod", option.value)}
+                style={[styles.optionCard, active && styles.optionCardActive]}
+                testID={`contact-method-${option.value}`}
+              >
+                <Text
+                  style={[
+                    styles.optionTitle,
+                    active && styles.optionTitleActive,
+                  ]}
+                >
+                  {option.title}
+                </Text>
+                <Text
+                  style={[styles.optionBody, active && styles.optionBodyActive]}
+                >
+                  {option.body}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      </View>
+
+      <View style={styles.fieldGroup}>
+        <Text style={styles.label}>Bio</Text>
+        <TextInput
+          multiline
+          onChangeText={(value) => onChange("bio", value)}
+          placeholder="Tell farms a bit about how you shop or collect orders"
+          placeholderTextColor="#7A867D"
+          style={[styles.input, styles.textArea]}
+          textAlignVertical="top"
+          value={draft.bio}
+        />
+      </View>
+      <View style={styles.fieldGroup}>
+        <Text style={styles.label}>Pickup notes</Text>
+        <TextInput
+          multiline
+          onChangeText={(value) => onChange("defaultPickupNotes", value)}
+          placeholder="Examples: call on arrival, small blue car, collect after 17:00"
+          placeholderTextColor="#7A867D"
+          style={[styles.input, styles.textArea]}
+          textAlignVertical="top"
+          value={draft.defaultPickupNotes}
+        />
+      </View>
+
+      <View style={styles.actionRow}>
+        <Pressable
+          accessibilityRole="button"
+          disabled={loading}
+          onPress={onSave}
+          style={[styles.primaryButton, loading && styles.buttonDisabled]}
+          testID="save-profile-button"
+        >
+          {loading ? (
+            <ActivityIndicator color="#FFFFFF" />
+          ) : (
+            <Text style={styles.primaryButtonText}>Save profile</Text>
+          )}
+        </Pressable>
+        <Pressable
+          accessibilityRole="button"
+          disabled={loading}
+          onPress={onCancel}
+          style={styles.secondaryButton}
+          testID="cancel-profile-button"
+        >
+          <Text style={styles.secondaryButtonText}>Cancel</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+function FarmerProfileView() {
+  return (
+    <View style={styles.panel}>
+      <Text style={styles.panelTitle}>Farmer profile</Text>
+      <Text style={styles.panelBody}>
+        Farmer accounts will get a separate profile editor once farm-specific
+        fields are designed. This customer profile form is intentionally not
+        shown here.
+      </Text>
+    </View>
+  );
+}
+
 export default function AccountScreen() {
-  const { profile, profileError, profileLoading, signOut, user } = useAuth();
-  const [loading, setLoading] = useState(false);
+  const {
+    profile,
+    profileError,
+    profileLoading,
+    signOut,
+    updateOwnProfile,
+    user,
+  } = useAuth();
+  const [draft, setDraft] = useState<CustomerProfileDraft>(
+    createCustomerDraft(profile),
+  );
+  const [isEditing, setIsEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [signingOut, setSigningOut] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const customerDraft = isEditing ? draft : createCustomerDraft(profile);
+
+  const resetDraft = () => {
+    setDraft(createCustomerDraft(profile));
+  };
+
+  const handleCustomerFieldChange = <K extends keyof CustomerProfileDraft>(
+    key: K,
+    value: CustomerProfileDraft[K],
+  ) => {
+    setDraft((current) => ({
+      ...current,
+      [key]: value,
+    }));
+  };
+
+  const handleEdit = () => {
+    resetDraft();
+    setErrorMessage(null);
+    setSuccessMessage(null);
+    setIsEditing(true);
+  };
+
+  const handleCancel = () => {
+    resetDraft();
+    setErrorMessage(null);
+    setSuccessMessage(null);
+    setIsEditing(false);
+  };
+
+  const handleSave = async () => {
+    try {
+      setSaving(true);
+      setErrorMessage(null);
+      setSuccessMessage(null);
+      await updateOwnProfile(draft);
+      setSuccessMessage("Customer profile updated.");
+      setIsEditing(false);
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Unable to update profile.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
 
   const handleSignOut = async () => {
     try {
-      setLoading(true);
+      setSigningOut(true);
       setErrorMessage(null);
       await signOut();
     } catch (error) {
@@ -26,90 +460,285 @@ export default function AccountScreen() {
         error instanceof Error ? error.message : "Unable to sign out.",
       );
     } finally {
-      setLoading(false);
+      setSigningOut(false);
     }
   };
 
   return (
-    <AuthScreenShell
-      eyebrow="Account"
-      title="Your FarmConnect session is stored on this device."
-      subtitle="Supabase is now persisting the auth session locally, so reopening the app should keep you signed in until you sign out."
-      footer={
-        <Text style={styles.footerText}>
-          <Link href="/" style={styles.footerLink}>
-            Back to landing page
-          </Link>
-        </Text>
-      }
-    >
-      <View style={styles.infoCard}>
-        <Text style={styles.infoTitle}>Signed in account</Text>
-        <Text style={styles.infoValue}>{user?.email ?? "Unknown email"}</Text>
-        <Text style={styles.infoMeta}>
-          Email confirmed: {user?.email_confirmed_at ? "yes" : "no"}
-        </Text>
-      </View>
-      <View style={styles.infoCard}>
-        <Text style={styles.infoTitle}>Profile</Text>
+    <SafeAreaView style={styles.page}>
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        <ProfileHeader profile={profile} />
+
+        <AccountMetaCard
+          createdAt={profile?.createdAt}
+          email={user?.email}
+          role={profile?.role}
+          updatedAt={profile?.updatedAt}
+        />
+
         {profileLoading ? (
-          <Text style={styles.infoMeta}>Loading profile...</Text>
+          <View style={styles.loadingPanel}>
+            <ActivityIndicator color="#2F6A3E" />
+            <Text style={styles.panelBody}>Loading profile...</Text>
+          </View>
+        ) : profile?.role === "farmer" ? (
+          <FarmerProfileView />
         ) : (
-          <>
-            <Text style={styles.infoValue}>
-              {profile?.fullName ?? "No name saved yet"}
-            </Text>
-            <Text style={styles.infoMeta}>
-              Role: {profile?.role ?? "No role saved yet"}
-            </Text>
-          </>
+          <CustomerProfileView
+            draft={customerDraft}
+            isEditing={isEditing}
+            loading={saving}
+            onCancel={handleCancel}
+            onChange={handleCustomerFieldChange}
+            onEdit={handleEdit}
+            onSave={handleSave}
+          />
         )}
+
         {profileError ? (
           <Text style={styles.errorText}>{profileError}</Text>
         ) : null}
-      </View>
-      {errorMessage ? (
-        <Text style={styles.errorText}>{errorMessage}</Text>
-      ) : null}
-      <Pressable
-        disabled={loading}
-        onPress={handleSignOut}
-        style={[styles.primaryButton, loading && styles.buttonDisabled]}
-      >
-        {loading ? (
-          <ActivityIndicator color="#FFFFFF" />
-        ) : (
-          <Text style={styles.primaryButtonText}>Sign out</Text>
-        )}
-      </Pressable>
-    </AuthScreenShell>
+        {errorMessage ? (
+          <Text style={styles.errorText}>{errorMessage}</Text>
+        ) : null}
+        {successMessage ? (
+          <Text style={styles.successText}>{successMessage}</Text>
+        ) : null}
+
+        <View style={styles.bottomRow}>
+          <Pressable
+            accessibilityRole="button"
+            disabled={signingOut}
+            onPress={handleSignOut}
+            style={[
+              styles.primaryButton,
+              styles.signOutButton,
+              signingOut && styles.buttonDisabled,
+            ]}
+            testID="sign-out-button"
+          >
+            {signingOut ? (
+              <ActivityIndicator color="#FFFFFF" />
+            ) : (
+              <Text style={styles.primaryButtonText}>Sign out</Text>
+            )}
+          </Pressable>
+          <Text style={styles.footerText}>
+            <Link href={"/" as Href} style={styles.footerLink}>
+              Back to landing page
+            </Link>
+          </Text>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
+const shadow = {
+  boxShadow: "0px 18px 40px rgba(26, 41, 30, 0.08)",
+} as const;
+
 const styles = StyleSheet.create({
-  infoCard: {
+  page: {
+    flex: 1,
+    backgroundColor: "#F4F5EF",
+  },
+  scrollContent: {
+    gap: 16,
+    paddingHorizontal: 18,
+    paddingVertical: 24,
+  },
+  heroCard: {
+    backgroundColor: "#21432D",
+    borderRadius: 28,
+    gap: 16,
+    padding: 22,
+    ...shadow,
+  },
+  avatarCircle: {
+    alignItems: "center",
+    backgroundColor: "#F3E6BB",
+    borderRadius: 999,
+    height: 64,
+    justifyContent: "center",
+    width: 64,
+  },
+  avatarText: {
+    color: "#21432D",
+    fontSize: 22,
+    fontWeight: "800",
+  },
+  heroCopy: {
+    gap: 6,
+  },
+  eyebrow: {
+    color: "#B9D1BF",
+    fontSize: 12,
+    fontWeight: "700",
+    letterSpacing: 0.4,
+    textTransform: "uppercase",
+  },
+  heroTitle: {
+    color: "#FFFFFF",
+    fontSize: 28,
+    fontWeight: "800",
+    letterSpacing: -0.7,
+  },
+  heroBody: {
+    color: "#D8E2DB",
+    fontSize: 15,
+    lineHeight: 22,
+  },
+  panel: {
+    backgroundColor: "#FFFFFF",
+    borderColor: "#DFE4DB",
+    borderRadius: 24,
+    borderWidth: 1,
+    gap: 14,
+    padding: 18,
+    ...shadow,
+  },
+  loadingPanel: {
+    alignItems: "center",
+    backgroundColor: "#FFFFFF",
+    borderColor: "#DFE4DB",
+    borderRadius: 24,
+    borderWidth: 1,
+    flexDirection: "row",
+    gap: 10,
+    padding: 18,
+    ...shadow,
+  },
+  panelTitle: {
+    color: "#182019",
+    fontSize: 18,
+    fontWeight: "800",
+  },
+  panelBody: {
+    color: "#5D6A60",
+    fontSize: 14,
+    lineHeight: 21,
+  },
+  sectionHeader: {
+    gap: 12,
+  },
+  sectionCopy: {
+    gap: 4,
+  },
+  readonlyGrid: {
+    gap: 12,
+  },
+  readonlyItem: {
     backgroundColor: "#F7FBF5",
-    borderColor: "#D6E3D0",
+    borderColor: "#D7E2D3",
+    borderRadius: 18,
+    borderWidth: 1,
+    gap: 4,
+    padding: 14,
+  },
+  readonlyLabel: {
+    color: "#5D6A60",
+    fontSize: 12,
+    fontWeight: "700",
+    letterSpacing: 0.3,
+    textTransform: "uppercase",
+  },
+  readonlyValue: {
+    color: "#182019",
+    fontSize: 16,
+    fontWeight: "700",
+    lineHeight: 22,
+  },
+  readonlyMeta: {
+    color: "#445148",
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  textBlock: {
+    gap: 6,
+  },
+  longValue: {
+    color: "#213025",
+    fontSize: 15,
+    lineHeight: 22,
+  },
+  inlineButton: {
+    alignSelf: "flex-start",
+    backgroundColor: "#EEF5EB",
+    borderRadius: 999,
+    paddingHorizontal: 14,
+    paddingVertical: 9,
+  },
+  inlineButtonText: {
+    color: "#214C2D",
+    fontSize: 13,
+    fontWeight: "700",
+  },
+  formGrid: {
+    gap: 12,
+  },
+  fieldGroup: {
+    gap: 8,
+  },
+  label: {
+    color: "#182019",
+    fontSize: 14,
+    fontWeight: "700",
+  },
+  input: {
+    backgroundColor: "#FFFFFF",
+    borderColor: "#DDE4D9",
+    borderRadius: 18,
+    borderWidth: 1,
+    color: "#182019",
+    fontSize: 15,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+  },
+  textArea: {
+    minHeight: 110,
+  },
+  optionGrid: {
+    gap: 12,
+  },
+  optionCard: {
+    backgroundColor: "#FFFFFF",
+    borderColor: "#DDE4D9",
     borderRadius: 20,
     borderWidth: 1,
     gap: 6,
     padding: 16,
   },
-  infoTitle: {
+  optionCardActive: {
+    backgroundColor: "#EEF5EB",
+    borderColor: "#2F6A3E",
+  },
+  optionTitle: {
     color: "#182019",
     fontSize: 15,
     fontWeight: "700",
   },
-  infoValue: {
-    color: "#182019",
-    fontSize: 17,
-    lineHeight: 23,
-    fontWeight: "800",
+  optionTitleActive: {
+    color: "#214C2D",
   },
-  infoMeta: {
+  optionBody: {
     color: "#5D6A60",
     fontSize: 13,
     lineHeight: 20,
+  },
+  optionBodyActive: {
+    color: "#3A5441",
+  },
+  actionRow: {
+    gap: 10,
+    marginTop: 4,
+  },
+  bottomRow: {
+    gap: 12,
+    marginBottom: 8,
   },
   primaryButton: {
     alignItems: "center",
@@ -124,11 +753,33 @@ const styles = StyleSheet.create({
     fontSize: 15,
     fontWeight: "700",
   },
+  secondaryButton: {
+    alignItems: "center",
+    borderColor: "#BFD2B9",
+    borderRadius: 18,
+    borderWidth: 1,
+    justifyContent: "center",
+    minHeight: 52,
+    paddingHorizontal: 18,
+  },
+  secondaryButtonText: {
+    color: "#2F6A3E",
+    fontSize: 15,
+    fontWeight: "700",
+  },
+  signOutButton: {
+    backgroundColor: "#314A37",
+  },
   buttonDisabled: {
     opacity: 0.7,
   },
   errorText: {
     color: "#9C5B4D",
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  successText: {
+    color: "#2E5B3C",
     fontSize: 14,
     lineHeight: 20,
   },

--- a/src/lib/profiles.ts
+++ b/src/lib/profiles.ts
@@ -3,12 +3,19 @@ import type { User } from "@supabase/supabase-js";
 import { supabase } from "./supabase";
 
 export type ProfileRole = "customer" | "farmer";
+export type PreferredContactMethod = "email" | "phone";
 
 export type UserProfile = {
   id: string;
   email: string | null;
+  displayName: string | null;
   fullName: string | null;
   role: ProfileRole;
+  phoneNumber: string | null;
+  bio: string | null;
+  locationLabel: string | null;
+  preferredContactMethod: PreferredContactMethod;
+  defaultPickupNotes: string | null;
   createdAt: string;
   updatedAt: string;
 };
@@ -16,8 +23,14 @@ export type UserProfile = {
 type ProfileRow = {
   id: string;
   email: string | null;
+  display_name: string | null;
   full_name: string | null;
   role: string;
+  phone_number: string | null;
+  bio: string | null;
+  location_label: string | null;
+  preferred_contact_method: string;
+  default_pickup_notes: string | null;
   created_at: string;
   updated_at: string;
 };
@@ -25,8 +38,14 @@ type ProfileRow = {
 const profileSelect = `
   id,
   email,
+  display_name,
   full_name,
   role,
+  phone_number,
+  bio,
+  location_label,
+  preferred_contact_method,
+  default_pickup_notes,
   created_at,
   updated_at
 `;
@@ -45,12 +64,46 @@ export function normalizeFullName(value: unknown) {
   return trimmed ? trimmed : null;
 }
 
+export function normalizeOptionalText(value: unknown) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+
+  return trimmed ? trimmed : null;
+}
+
+export function normalizePreferredContactMethod(
+  value: unknown,
+): PreferredContactMethod {
+  return value === "phone" ? "phone" : "email";
+}
+
+type UpdateProfileInput = {
+  displayName: string;
+  fullName: string;
+  phoneNumber: string;
+  bio: string;
+  locationLabel: string;
+  preferredContactMethod: PreferredContactMethod;
+  defaultPickupNotes: string;
+};
+
 function mapProfile(row: ProfileRow): UserProfile {
   return {
     id: row.id,
     email: row.email,
+    displayName: row.display_name,
     fullName: row.full_name,
     role: normalizeProfileRole(row.role),
+    phoneNumber: row.phone_number,
+    bio: row.bio,
+    locationLabel: row.location_label,
+    preferredContactMethod: normalizePreferredContactMethod(
+      row.preferred_contact_method,
+    ),
+    defaultPickupNotes: row.default_pickup_notes,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -85,13 +138,56 @@ export async function upsertProfileFromUser(user: User) {
       {
         id: user.id,
         email: user.email ?? null,
+        display_name:
+          normalizeOptionalText(user.user_metadata?.display_name) ??
+          normalizeFullName(user.user_metadata?.full_name),
         full_name: normalizeFullName(user.user_metadata?.full_name),
         role: normalizeProfileRole(user.user_metadata?.role),
+        phone_number: normalizeOptionalText(user.user_metadata?.phone_number),
+        bio: normalizeOptionalText(user.user_metadata?.bio),
+        location_label: normalizeOptionalText(
+          user.user_metadata?.location_label,
+        ),
+        preferred_contact_method: normalizePreferredContactMethod(
+          user.user_metadata?.preferred_contact_method,
+        ),
+        default_pickup_notes: normalizeOptionalText(
+          user.user_metadata?.default_pickup_notes,
+        ),
       },
       {
         onConflict: "id",
       },
     )
+    .select(profileSelect)
+    .single<ProfileRow>();
+
+  if (error) {
+    throw error;
+  }
+
+  return mapProfile(data);
+}
+
+export async function updateProfile(userId: string, input: UpdateProfileInput) {
+  if (!supabase) {
+    throw new Error("Supabase is not configured.");
+  }
+
+  const { data, error } = await supabase
+    .from("profiles")
+    .update({
+      display_name: normalizeOptionalText(input.displayName),
+      full_name: normalizeFullName(input.fullName),
+      phone_number: normalizeOptionalText(input.phoneNumber),
+      bio: normalizeOptionalText(input.bio),
+      location_label: normalizeOptionalText(input.locationLabel),
+      preferred_contact_method: normalizePreferredContactMethod(
+        input.preferredContactMethod,
+      ),
+      default_pickup_notes: normalizeOptionalText(input.defaultPickupNotes),
+    })
+    .eq("id", userId)
     .select(profileSelect)
     .single<ProfileRow>();
 

--- a/src/providers/auth-provider.tsx
+++ b/src/providers/auth-provider.tsx
@@ -13,9 +13,13 @@ import type { Session, User } from "@supabase/supabase-js";
 import {
   fetchProfile,
   normalizeFullName,
+  normalizeOptionalText,
   normalizeProfileRole,
+  normalizePreferredContactMethod,
   type ProfileRole,
+  type PreferredContactMethod,
   type UserProfile,
+  updateProfile,
   upsertProfileFromUser,
 } from "../lib/profiles";
 import { isSupabaseConfigured, supabase } from "../lib/supabase";
@@ -29,6 +33,16 @@ type SignUpResult = {
 type SignUpProfileDetails = {
   fullName: string;
   role: ProfileRole;
+};
+
+type UpdateProfileDetails = {
+  displayName: string;
+  fullName: string;
+  phoneNumber: string;
+  bio: string;
+  locationLabel: string;
+  preferredContactMethod: PreferredContactMethod;
+  defaultPickupNotes: string;
 };
 
 type AuthContextValue = {
@@ -51,6 +65,7 @@ type AuthContextValue = {
   clearAuthLinkState: () => void;
   makeEmailRedirectUrl: () => string;
   refreshProfile: () => Promise<void>;
+  updateOwnProfile: (details: UpdateProfileDetails) => Promise<UserProfile>;
 };
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -360,6 +375,62 @@ export function AuthProvider({ children }: PropsWithChildren) {
       },
       async refreshProfile() {
         await syncProfile(session?.user ?? null);
+      },
+      async updateOwnProfile(details) {
+        if (!supabase) {
+          throw new Error("Supabase is not configured.");
+        }
+
+        if (!session?.user) {
+          throw new Error("You must be signed in to update your profile.");
+        }
+
+        const fullName = normalizeFullName(details.fullName);
+
+        if (!fullName) {
+          throw new Error("Enter your name before saving the profile.");
+        }
+
+        const displayName =
+          normalizeOptionalText(details.displayName) ?? fullName;
+        const phoneNumber = normalizeOptionalText(details.phoneNumber);
+        const bio = normalizeOptionalText(details.bio);
+        const locationLabel = normalizeOptionalText(details.locationLabel);
+        const preferredContactMethod = normalizePreferredContactMethod(
+          details.preferredContactMethod,
+        );
+        const defaultPickupNotes = normalizeOptionalText(
+          details.defaultPickupNotes,
+        );
+        const nextProfile = await updateProfile(session.user.id, {
+          displayName,
+          fullName,
+          phoneNumber: phoneNumber ?? "",
+          bio: bio ?? "",
+          locationLabel: locationLabel ?? "",
+          preferredContactMethod,
+          defaultPickupNotes: defaultPickupNotes ?? "",
+        });
+        const { error } = await supabase.auth.updateUser({
+          data: {
+            display_name: displayName,
+            full_name: fullName,
+            phone_number: phoneNumber,
+            bio,
+            location_label: locationLabel,
+            preferred_contact_method: preferredContactMethod,
+            default_pickup_notes: defaultPickupNotes,
+          },
+        });
+
+        if (error) {
+          throw error;
+        }
+
+        setProfile(nextProfile);
+        setProfileError(null);
+
+        return nextProfile;
       },
     }),
     [

--- a/supabase/migrations/202603301100_add_customer_profile_fields.sql
+++ b/supabase/migrations/202603301100_add_customer_profile_fields.sql
@@ -1,0 +1,12 @@
+alter table public.profiles
+add column if not exists display_name text,
+add column if not exists phone_number text,
+add column if not exists bio text,
+add column if not exists location_label text,
+add column if not exists preferred_contact_method text not null default 'email'
+  check (preferred_contact_method in ('email', 'phone')),
+add column if not exists default_pickup_notes text;
+
+update public.profiles
+set display_name = coalesce(display_name, full_name)
+where display_name is null;

--- a/tests/account-screen.test.tsx
+++ b/tests/account-screen.test.tsx
@@ -1,0 +1,163 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react-native";
+
+import AccountScreen from "../src/app/account";
+import type { UserProfile } from "../src/lib/profiles";
+
+const mockSignOut = jest.fn();
+const mockUpdateOwnProfile = jest.fn();
+const mockUser = {
+  id: "user-1",
+  email: "test@example.com",
+  email_confirmed_at: "2026-03-30T12:00:00.000Z",
+};
+const mockCustomerProfile: UserProfile = {
+  id: "user-1",
+  email: "test@example.com",
+  displayName: "Ava",
+  fullName: "Ava Fields",
+  role: "customer" as const,
+  phoneNumber: "+47 999 99 999",
+  bio: "Weekly produce shopper who prefers afternoon collections.",
+  locationLabel: "Kristiansand",
+  preferredContactMethod: "phone" as const,
+  defaultPickupNotes: "Call when you arrive at the gate.",
+  createdAt: "2026-03-10T08:30:00.000Z",
+  updatedAt: "2026-03-25T14:45:00.000Z",
+};
+const mockFarmerProfile: UserProfile = {
+  ...mockCustomerProfile,
+  role: "farmer" as const,
+};
+
+let mockCurrentProfile: UserProfile = mockCustomerProfile;
+
+jest.mock("expo-router", () => {
+  const React = require("react");
+  const { Text } = require("react-native");
+
+  return {
+    Link: ({ children }: { children: React.ReactNode }) => (
+      <Text>{children}</Text>
+    ),
+  };
+});
+
+jest.mock("../src/providers/auth-provider", () => ({
+  useAuth: () => ({
+    session: {
+      user: {
+        id: "user-1",
+        email: "test@example.com",
+      },
+    },
+    user: mockUser,
+    profile: mockCurrentProfile,
+    profileLoading: false,
+    profileError: null,
+    isLoading: false,
+    authLinkStatus: "idle",
+    authLinkMessage: null,
+    signInWithPassword: jest.fn(),
+    signUpWithPassword: jest.fn(),
+    resendConfirmationEmail: jest.fn(),
+    signOut: mockSignOut,
+    clearAuthLinkState: jest.fn(),
+    makeEmailRedirectUrl: () => "farmconnect://auth/confirm",
+    refreshProfile: jest.fn(),
+    updateOwnProfile: mockUpdateOwnProfile,
+  }),
+}));
+
+describe("AccountScreen", () => {
+  beforeEach(() => {
+    mockCurrentProfile = mockCustomerProfile;
+    mockSignOut.mockReset();
+    mockUpdateOwnProfile.mockReset();
+  });
+
+  it("renders the customer profile and readonly account fields", () => {
+    render(<AccountScreen />);
+
+    expect(screen.getAllByText("Customer profile")).toHaveLength(2);
+    expect(screen.getByText("Account details")).toBeTruthy();
+    expect(screen.getByText("test@example.com")).toBeTruthy();
+    expect(screen.getByText("Customer")).toBeTruthy();
+    expect(screen.getAllByText("Ava")).toHaveLength(2);
+    expect(screen.getByText("+47 999 99 999")).toBeTruthy();
+    expect(screen.getAllByText("Kristiansand")).toHaveLength(2);
+    expect(screen.getByText("Phone")).toBeTruthy();
+    expect(screen.getByText("Call when you arrive at the gate.")).toBeTruthy();
+    expect(screen.getByText("Edit customer profile")).toBeTruthy();
+  });
+
+  it("lets the customer edit and save profile fields", async () => {
+    mockUpdateOwnProfile.mockResolvedValue({
+      ...mockCustomerProfile,
+      displayName: "Ava Green",
+      fullName: "Ava Marie Green",
+      preferredContactMethod: "email",
+      locationLabel: "Lillesand",
+      bio: "Collects after work and prefers email reminders.",
+      defaultPickupNotes: "Usually arrives around 17:30.",
+    });
+
+    render(<AccountScreen />);
+
+    fireEvent.press(screen.getByTestId("edit-profile-button"));
+    fireEvent.changeText(screen.getByDisplayValue("Ava"), "Ava Green");
+    fireEvent.changeText(
+      screen.getByDisplayValue("Ava Fields"),
+      "Ava Marie Green",
+    );
+    fireEvent.changeText(
+      screen.getByDisplayValue("+47 999 99 999"),
+      "+47 111 22 333",
+    );
+    fireEvent.changeText(screen.getByDisplayValue("Kristiansand"), "Lillesand");
+    fireEvent.press(screen.getByTestId("contact-method-email"));
+    fireEvent.changeText(
+      screen.getByDisplayValue(
+        "Weekly produce shopper who prefers afternoon collections.",
+      ),
+      "Collects after work and prefers email reminders.",
+    );
+    fireEvent.changeText(
+      screen.getByDisplayValue("Call when you arrive at the gate."),
+      "Usually arrives around 17:30.",
+    );
+    fireEvent.press(screen.getByTestId("save-profile-button"));
+
+    await waitFor(() => {
+      expect(mockUpdateOwnProfile).toHaveBeenCalledWith({
+        displayName: "Ava Green",
+        fullName: "Ava Marie Green",
+        phoneNumber: "+47 111 22 333",
+        locationLabel: "Lillesand",
+        preferredContactMethod: "email",
+        bio: "Collects after work and prefers email reminders.",
+        defaultPickupNotes: "Usually arrives around 17:30.",
+      });
+    });
+
+    expect(screen.getByText("Customer profile updated.")).toBeTruthy();
+  });
+
+  it("shows a separate farmer view without the customer editor", () => {
+    mockCurrentProfile = mockFarmerProfile;
+
+    render(<AccountScreen />);
+
+    expect(screen.getAllByText("Farmer profile")).toHaveLength(2);
+    expect(
+      screen.getByText(
+        "Farmer accounts will get a separate profile editor once farm-specific fields are designed. This customer profile form is intentionally not shown here.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText("Edit customer profile")).toBeNull();
+  });
+});


### PR DESCRIPTION
PR implementing #18 and #19.

## Summary
- replace the old generic account page with a dedicated customer profile view/edit flow
- keep email, account type, account creation date, and last updated as read-only
- split farmer handling into a separate non-editable placeholder view for now
- add customer-specific profile fields and persist them through Supabase/profile syncing

## Changes
- added editable customer fields:
  - display name
  - full name
  - phone number
  - location
  - preferred contact method
  - bio
  - pickup notes
- extended the profile model and auth provider update path
- added a Supabase migration for the new customer profile columns
- added screen tests for:
  - customer profile rendering
  - customer profile editing
  - separate farmer profile view
 
farmer/customer role is read-only for now
farmer profile editing is intentionally deferred to a separate role-specific flow