### PR TITLE
Added basic farm map screen with mock markers

### DIFF
--- a/app.json
+++ b/app.json
@@ -27,6 +27,12 @@
     "plugins": [
       "expo-router",
       [
+        "react-native-maps",
+        {
+           "androidGoogleMapsApiKey": "AIzaSyCRF2RPklf3lpsvbX5xz-YXW6l3owPD2Hk"
+        }
+      ],
+      [
         "expo-splash-screen",
         {
           "backgroundColor": "#208AEF",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "react-dom": "19.2.0",
         "react-native": "0.83.2",
         "react-native-gesture-handler": "~2.30.0",
+        "react-native-maps": "1.27.2",
         "react-native-reanimated": "4.2.1",
         "react-native-safe-area-context": "~5.6.2",
         "react-native-screens": "~4.23.0",
@@ -81,6 +82,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1972,6 +1974,7 @@
       "resolved": "https://registry.npmjs.org/@expo/log-box/-/log-box-55.0.7.tgz",
       "integrity": "sha512-m7V1k2vlMp4NOj3fopjOg4zl/ANXyTRF3HMTMep2GZAKsPiDzgOQ41nm8CaU50/HlDIGXlCObss07gOn20UpHQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@expo/dom-webview": "^55.0.3",
         "anser": "^1.4.9",
@@ -3788,6 +3791,7 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.34.tgz",
       "integrity": "sha512-zzQ0mKAhLsjTIsaoLfILKZVMObJzE0F+bOi0hl2Glt+1Rd2GtaWJ1Z024c3yLmX+Oc79pqoCQLBXpyxtrZu9NQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.16.2",
         "escape-string-regexp": "^4.0.0",
@@ -4137,6 +4141,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -4283,6 +4293,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4369,6 +4380,7 @@
       "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -4889,6 +4901,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5680,6 +5693,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6938,6 +6952,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7121,6 +7136,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7764,6 +7780,7 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-55.0.8.tgz",
       "integrity": "sha512-sziDGiDmeRmaSpFwMuSxFhr4vfWrQS1UgVXSTovsUDY0ximABzYdnF5L2OwtD8zjtIww8x2oJGmD6mKS+AoVsw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "55.0.18",
@@ -7833,6 +7850,7 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.9.tgz",
       "integrity": "sha512-iBiXjZeuU5S/8docQeNzsVvtDy4w0zlmXBpFEi1ypwugceEpdQQab65TVRbusXAcwpNVxCPMpNlDssYp0Pli2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@expo/config": "~55.0.10",
         "@expo/env": "~2.1.1"
@@ -7869,6 +7887,7 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-55.0.4.tgz",
       "integrity": "sha512-ZKeGTFffPygvY5dM/9ATM2p7QDkhsaHopH7wFAWgP2lKzqUMS9B/RxCvw5CaObr9Ro7x9YptyeRKX2HmgmMfrg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -7924,6 +7943,7 @@
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-55.0.8.tgz",
       "integrity": "sha512-O9QgKAfEqKfsjL6IKs5p7pFAjo/3/TQwjMzzNPl8BCndbxWMPQfMeViXPYYNS9bA2ujUqrtF1OYhO6woI7GNQQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "expo-constants": "~55.0.8",
         "invariant": "^2.2.4"
@@ -8053,6 +8073,7 @@
       "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-55.0.6.tgz",
       "integrity": "sha512-xI72FTm469FfuuBL2R5aNtthgH+GR7ygOpsx/KcPS0K8AZaZd7VjtEExbzn9/qyyYkWW3T+3dAmCDKOMX8gdmQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.16.0"
       }
@@ -9944,6 +9965,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -13378,6 +13400,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13397,6 +13420,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -13433,6 +13457,7 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.83.2.tgz",
       "integrity": "sha512-ZDma3SLkRN2U2dg0/EZqxNBAx4of/oTnPjXAQi299VLq2gdnbZowGy9hzqv+O7sTA62g+lM1v+2FM5DUnJ/6hg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.83.2",
@@ -13491,6 +13516,7 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.30.0.tgz",
       "integrity": "sha512-5YsnKHGa0X9C8lb5oCnKm0fLUPM6CRduvUUw2Bav4RIj/C3HcFh4RIUnF8wgG6JQWCL1//gRx4v+LVWgcIQdGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -13509,6 +13535,28 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-maps": {
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.27.2.tgz",
+      "integrity": "sha512-VKr+xZ2RZGHHJlY6KhlafvGSmK0dq/tUu5uhfJ7K9rwN5pUdubdugzMKGDU/16lXmQSg7xbClKhRctj3Pm5F5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.13"
+      },
+      "engines": {
+        "node": ">= 20.19.4"
+      },
+      "peerDependencies": {
+        "react": ">= 18.3.1",
+        "react-native": ">= 0.76.0",
+        "react-native-web": ">= 0.11"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native-reanimated": {
@@ -13553,6 +13601,7 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -13563,6 +13612,7 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.23.0.tgz",
       "integrity": "sha512-XhO3aK0UeLpBn4kLecd+J+EDeRRJlI/Ro9Fze06vo1q163VeYtzfU9QS09/VyDFMWR1qxDC1iazCArTPSFFiPw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
@@ -13589,6 +13639,7 @@
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
       "integrity": "sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
@@ -13860,6 +13911,7 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13939,6 +13991,7 @@
       "integrity": "sha512-zLCFMHFE9vy/w3AxO0zNxy6aAupnCuLSVOJYDe/Tp+ayGI1f2PLQsFVPANSD42gdSbmYx5oN+1VWDhcXtq7hAQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-is": "^19.2.0",
         "scheduler": "^0.27.0"
@@ -15551,6 +15604,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-dom": "19.2.0",
     "react-native": "0.83.2",
     "react-native-gesture-handler": "~2.30.0",
+    "react-native-maps": "1.27.2",
     "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.23.0",

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -344,6 +344,12 @@ export default function Index() {
                 >
                   Go to order
                 </Link>
+                <Link
+                  href={"/map"}
+                  style={[styles.ctaLink, styles.ctaLinkPrimary]}
+                >
+                  Open map
+                </Link>
               </View>
             </View>
 

--- a/src/app/map.tsx
+++ b/src/app/map.tsx
@@ -1,0 +1,41 @@
+import { mockFarmProfiles } from "@/lib/mockFarmProfiles";
+import { StyleSheet, View } from "react-native";
+import MapView, { Marker, PROVIDER_GOOGLE } from "react-native-maps";
+
+
+export default function MapScreen() {
+  return (
+    <View style={styles.container}>
+      <MapView
+      provider={PROVIDER_GOOGLE}
+      style={styles.map}
+        initialRegion={{
+            latitude: 58.1467,
+            longitude: 7.9956,
+            latitudeDelta: 0.5,
+            longitudeDelta: 0.5,
+        }}
+        >
+    
+      {mockFarmProfiles.map((farm) => 
+        typeof farm.latitude === "number" && typeof farm.longitude === "number" ? (
+            <Marker
+            key={farm.id}
+            coordinate={{
+                latitude: farm.latitude,
+                longitude: farm.longitude,
+            }}
+            title={farm.farm_name}
+            description={farm.farm_bio ?? ""}
+            />
+        ) : null
+        )}
+    </MapView>
+   </View>
+  );
+}
+
+const styles = StyleSheet.create({
+    container: {flex: 1,},
+    map: {flex: 1,},
+});

--- a/src/lib/mockFarmProfiles.ts
+++ b/src/lib/mockFarmProfiles.ts
@@ -1,0 +1,40 @@
+export type  MockFarmProfile = {
+  id: string;
+  user_id: string;
+  farm_name: string;
+  farm_bio: string | null;
+  farm_location: string | null;
+  farm_profile_picture_url: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export const mockFarmProfiles: MockFarmProfile[] = [
+      {
+    id: "1",
+    user_id: "1",
+    farm_name: "Green Valley Farm",
+    farm_bio: "We grow organic vegetables and fruits.",
+    farm_location: "Kristiansand",
+    farm_profile_picture_url: null,
+    latitude: 58.1467,
+    longitude: 7.9956,
+    created_at: "2024-01-01T12:00:00Z",
+    updated_at: "2024-01-01T12:00:00Z",
+  },
+    {
+    id: "2",
+    user_id: "2",
+    farm_name: "Sunny Fields",
+    farm_bio: "We specialize in growing sunflowers and other cheerful blooms.",
+    farm_location: "Grimstad",
+    farm_profile_picture_url: null,
+    latitude: 58.3405,
+    longitude: 8.5934,
+    created_at: "2024-01-02T12:00:00Z",
+    updated_at: "2024-01-02T12:00:00Z",
+  },
+];
+


### PR DESCRIPTION
This PR integrates Google Maps into the FarmConnect application and adds an initial map screen using mock farm profile data.

## What's included

- Installed and configured `react-native-maps`
- Added Google Maps provider setup
- Added Android Google Maps API key configuration
- Created a map screen that renders farm markers from `mockFarmProfiles`

## Notes

- This PR uses mock data only for now
- The current implementation may only work correctly through `npm run android`
- Implementation documentation: https://docs.expo.dev/versions/latest/sdk/map-view/
- Click "Open map" to see map view


<img width="364" height="241" alt="Skjermbilde 2026-04-03 181032" src="https://github.com/user-attachments/assets/37e9195e-49e7-4d37-b73e-878a85af74d1" />

Map view:
<img width="383" height="587" alt="Skjermbilde 2026-04-03 180620" src="https://github.com/user-attachments/assets/1b1620f7-347f-4744-b23d-dc5d7fb054c3" />
<img width="388" height="545" alt="Skjermbilde 2026-04-03 180632" src="https://github.com/user-attachments/assets/6aa22fb1-858f-4cb0-b5d1-d80b18ab1fc5" />
