### PR TITLE
Added produce list screen and detail navigation

### DIFF
--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -351,10 +351,10 @@ export default function Index() {
                   Open map
                 </Link>
                 <Link
-                  href={"/produce/egg" as Href}
+                  href={"/produce" as Href}
                   style={[styles.ctaLink, styles.ctaLinkPrimary]}
                 >
-                  Open produce egg
+                  Open produce list
                 </Link>
               </View>
             </View>

--- a/src/app/produce/[produce].tsx
+++ b/src/app/produce/[produce].tsx
@@ -1,6 +1,7 @@
+import { produceStyles } from "@/styles/produce-styles";
 import * as Linking from "expo-linking";
 import { useLocalSearchParams } from "expo-router";
-import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { Pressable, ScrollView, Text, View } from "react-native";
 import produceData from "../../data/produceData.json";
 
 // Complete product data structure based on the output from generateProductData.ts
@@ -61,9 +62,9 @@ function formatValue(value: number | null, unit: string): string {
 
 function NutritionRow({ label, value }: { label: string; value: string }) {
   return (
-    <View style={styles.nutritionRow}>
-      <Text style={styles.nutritionLabel}>{label}</Text>
-      <Text style={styles.nutritionValue}>{value}</Text>
+    <View style={produceStyles.nutritionRow}>
+      <Text style={produceStyles.nutritionLabel}>{label}</Text>
+      <Text style={produceStyles.nutritionValue}>{value}</Text>
     </View>
   );
 }
@@ -74,123 +75,68 @@ export default function ProduceScreen() {
 
   if (!item) {
     return (
-      <View style={styles.container}>
-        <Text style={styles.errorText}>Product not found</Text>
+      <View style={produceStyles.container}>
+        <View style={produceStyles.card}>
+          <Text style={produceStyles.errorText}>Product not found</Text>
+        </View>
       </View>
     );
   }
 
   return (
-    <ScrollView contentContainerStyle={styles.container}>
-      <Text style={styles.title}>{item.name_nb}</Text>
+    <ScrollView
+      style={produceStyles.scrollView}
+      contentContainerStyle={produceStyles.scrollContent}
+    >
+      <View style={produceStyles.card}>
+        <Text style={produceStyles.title}>{item.name_nb}</Text>
 
-      {item.name_en ? (
-        <Text style={styles.subtitle}>{item.name_en}</Text>
-      ) : null}
+        {item.name_en ? (
+          <Text style={produceStyles.detail}>{item.name_en}</Text>
+        ) : null}
 
-      <View style={styles.metaBox}>
-        <Text style={styles.metaText}>Category: {item.category}</Text>
-        <Text style={styles.metaText}>Per: {item.nutrition.per}</Text>
-        <Text style={styles.metaText}>Food ID: {item.foodId}</Text>
-      </View>
+        <View style={produceStyles.metaBox}>
+          <Text style={produceStyles.metaText}>Category: {item.category}</Text>
+          <Text style={produceStyles.metaText}>Per: {item.nutrition.per}</Text>
+          <Text style={produceStyles.metaText}>Food ID: {item.foodId}</Text>
+        </View>
 
-      {item.matvareUrl_nb ? (
-        <Pressable
-          onPress={() => Linking.openURL(item.matvareUrl_nb!)}
-          style={styles.linkButton}
-        >
-          <Text style={styles.linkText}>
-            Source (Norwegian): Matvaretabellen
-          </Text>
-        </Pressable>
-      ) : null}
+        {item.matvareUrl_nb ? (
+          <Pressable
+            onPress={() => Linking.openURL(item.matvareUrl_nb!)}
+            style={produceStyles.linkButton}
+          >
+            <Text style={produceStyles.linkText}>
+              Source (Norwegian): Matvaretabellen
+            </Text>
+          </Pressable>
+        ) : null}
 
-      {item.matvareUrl_en ? (
-        <Pressable
-          onPress={() => Linking.openURL(item.matvareUrl_en!)}
-          style={styles.linkButton}
-        >
-          <Text style={styles.linkText}>Source (English): Matvaretabellen</Text>
-        </Pressable>
-      ) : null}
+        {item.matvareUrl_en ? (
+          <Pressable
+            onPress={() => Linking.openURL(item.matvareUrl_en!)}
+            style={produceStyles.linkButton}
+          >
+            <Text style={produceStyles.linkText}>
+              Source (English): Matvaretabellen
+            </Text>
+          </Pressable>
+        ) : null}
 
-      <View style={styles.nutritionTable}>
-        <Text style={styles.tableTitle}>Nutrition</Text>
-        {nutritionFields.map((field) => (
-          <NutritionRow
-            key={field.key}
-            label={field.label}
-            value={formatValue(item.nutrition[field.key] as number, field.unit)}
-          />
-        ))}
+        <View style={produceStyles.nutritionTable}>
+          <Text style={produceStyles.tableTitle}>Nutrition</Text>
+          {nutritionFields.map((field) => (
+            <NutritionRow
+              key={field.key}
+              label={field.label}
+              value={formatValue(
+                item.nutrition[field.key] as number,
+                field.unit,
+              )}
+            />
+          ))}
+        </View>
       </View>
     </ScrollView>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    padding: 16,
-    gap: 12,
-  },
-  title: {
-    fontSize: 28,
-    fontWeight: "700",
-  },
-  subtitle: {
-    fontSize: 16,
-    color: "#666",
-  },
-  metaBox: {
-    padding: 12,
-    borderWidth: 1,
-    borderColor: "#ddd",
-    borderRadius: 8,
-    gap: 4,
-    backgroundColor: "#f8f8f8",
-  },
-  metaText: {
-    fontSize: 14,
-  },
-  linkButton: {
-    paddingVertical: 4,
-  },
-  linkText: {
-    fontSize: 15,
-    fontWeight: "600",
-    color: "#1d4ed8",
-  },
-  nutritionTable: {
-    borderWidth: 1,
-    borderColor: "#ddd",
-    borderRadius: 8,
-    overflow: "hidden",
-  },
-  tableTitle: {
-    fontSize: 18,
-    fontWeight: "700",
-    padding: 12,
-    borderBottomWidth: 1,
-    borderBottomColor: "#ddd",
-    backgroundColor: "#f5f5f5",
-  },
-  nutritionRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    paddingHorizontal: 12,
-    paddingVertical: 10,
-    borderBottomWidth: 1,
-    borderBottomColor: "#eee",
-  },
-  nutritionLabel: {
-    fontSize: 15,
-  },
-  nutritionValue: {
-    fontSize: 15,
-    fontWeight: "600",
-  },
-  errorText: {
-    fontSize: 18,
-    color: "red",
-  },
-});

--- a/src/app/produce/index.tsx
+++ b/src/app/produce/index.tsx
@@ -1,0 +1,43 @@
+import { produceStyles } from "@/styles/produce-styles";
+import { useRouter } from "expo-router";
+import { Pressable, ScrollView, Text, View } from "react-native";
+import produceData from "../../data/produceData.json";
+
+type ProductDataItem = {
+  id: string;
+  name_nb: string;
+  name_en: string | null;
+};
+
+type ProduceDataFile = {
+  items: ProductDataItem[];
+};
+
+const typedProduceData = produceData as ProduceDataFile;
+
+export default function ProduceListScreen() {
+  const router = useRouter();
+
+  return (
+    <View style={produceStyles.container}>
+      <View style={produceStyles.card}>
+        <Text style={produceStyles.title}>Produce List</Text>
+
+        <ScrollView
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={produceStyles.listContent}
+        >
+          {typedProduceData.items.map((item) => (
+            <Pressable
+              key={item.id}
+              onPress={() => router.push(`/produce/${item.id}`)}
+              style={produceStyles.produceItem}
+            >
+              <Text style={produceStyles.produceName}>{item.name_nb}</Text>
+            </Pressable>
+          ))}
+        </ScrollView>
+      </View>
+    </View>
+  );
+}

--- a/src/styles/produce-styles.tsx
+++ b/src/styles/produce-styles.tsx
@@ -1,0 +1,109 @@
+import { StyleSheet } from "react-native";
+
+export const produceStyles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#F6F7F3",
+    padding: 18,
+    paddingTop: 32,
+  },
+  scrollView: {
+    flex: 1,
+    backgroundColor: "#F6F7F3",
+  },
+  scrollContent: {
+    padding: 18,
+    paddingTop: 32,
+  },
+  card: {
+    flex: 1,
+    backgroundColor: "rgba(255,255,255,0.88)",
+    borderWidth: 1,
+    borderColor: "#DDE4D9",
+    borderRadius: 32,
+    padding: 24,
+    gap: 12,
+    overflow: "hidden",
+    boxShadow: "0px 18px 30px rgba(24, 32, 25, 0.08)",
+  },
+  title: {
+    color: "#182019",
+    fontSize: 28,
+    fontWeight: "800",
+    letterSpacing: -0.8,
+    lineHeight: 32,
+  },
+  detail: {
+    color: "#5D6A60",
+    fontSize: 15,
+    lineHeight: 23,
+  },
+  produceItem: {
+    paddingVertical: 14,
+  },
+  produceName: {
+    color: "#182019",
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  metaBox: {
+    padding: 12,
+    borderWidth: 1,
+    borderColor: "#DDE4D9",
+    borderRadius: 16,
+    gap: 4,
+    backgroundColor: "#F8FAF6",
+  },
+  metaText: {
+    color: "#5D6A60",
+    fontSize: 14,
+  },
+  linkButton: {
+    paddingVertical: 4,
+  },
+  linkText: {
+    color: "#2F6A3E",
+    fontSize: 15,
+    fontWeight: "600",
+  },
+  nutritionTable: {
+    borderWidth: 1,
+    borderColor: "#DDE4D9",
+    borderRadius: 16,
+    overflow: "hidden",
+    backgroundColor: "#FFFFFF",
+  },
+  tableTitle: {
+    color: "#182019",
+    fontSize: 18,
+    fontWeight: "700",
+    padding: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: "#DDE4D9",
+    backgroundColor: "#F8FAF6",
+  },
+  nutritionRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: "#EEF2EC",
+  },
+  nutritionLabel: {
+    color: "#182019",
+    fontSize: 15,
+  },
+  nutritionValue: {
+    color: "#182019",
+    fontSize: 15,
+    fontWeight: "600",
+  },
+  errorText: {
+    fontSize: 18,
+    color: "#B42318",
+  },
+  listContent: {
+    paddingBottom: 12,
+  },
+});


### PR DESCRIPTION
Added a basic produce view. Each item is clickable and opens a more detailed page with nutrients and source links.

Closes issue: https://github.com/lindestad/farm-connect/issues/57

<table>
  <tr>
    <td>
      <img width="378" alt="Produce list" src="https://github.com/user-attachments/assets/68b73eba-37b1-4a40-9a9f-d8c22ee1f6e4" />
    </td>
    <td>
      <img width="385" alt="Produce detail view" src="https://github.com/user-attachments/assets/ffeeb9a3-183b-4886-b700-d235069abb30" />
    </td>
  </tr>
</table>