### PR TITLE
feat: add farm profile view, edit, and delete #22

### DIFF
--- a/src/app/farm/[farmId].tsx
+++ b/src/app/farm/[farmId].tsx
@@ -1,0 +1,186 @@
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useEffect, useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { FarmHeroCard } from "../../components/FarmHeroCard";
+import {
+  deleteFarmProfile,
+  type FarmProfile,
+  fetchFarmProfileById,
+} from "../../lib/farmProfiles";
+import { useAuth } from "../../providers/auth-provider";
+import { farmStyles } from "../../styles/farm-styles";
+
+// Helper function to format ISO timestamps into a more readable format
+function formatTimestamp(value: string): string {
+  return new Date(value).toLocaleString("en-GB", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+// Panel component to display farm details and actions for the owner
+function FarmDetailsPanel({
+  farmProfile,
+  isOwner,
+  onEdit,
+  onDelete,
+  deleting,
+}: {
+  farmProfile: FarmProfile;
+  isOwner: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+  deleting: boolean;
+}) {
+  return (
+    <View style={farmStyles.panel}>
+      <View style={farmStyles.sectionHeader}>
+        <Text style={farmStyles.panelTitle}>Farm details</Text>
+        {isOwner ? (
+          <Pressable
+            accessibilityRole="button"
+            onPress={onEdit}
+            style={farmStyles.inlineButton}
+          >
+            <Text style={farmStyles.inlineButtonText}>Edit farm profile</Text>
+          </Pressable>
+        ) : null}
+      </View>
+
+      <View style={farmStyles.readonlyGrid}>
+        <View style={farmStyles.readonlyItem}>
+          <Text style={farmStyles.readonlyLabel}>Created</Text>
+          <Text style={farmStyles.readonlyMeta}>
+            {formatTimestamp(farmProfile.created_at)}
+          </Text>
+        </View>
+        <View style={farmStyles.readonlyItem}>
+          <Text style={farmStyles.readonlyLabel}>Last updated</Text>
+          <Text style={farmStyles.readonlyMeta}>
+            {formatTimestamp(farmProfile.updated_at)}
+          </Text>
+        </View>
+      </View>
+
+      {farmProfile.farm_bio ? (
+        <View style={farmStyles.textBlock}>
+          <Text style={farmStyles.readonlyLabel}>About</Text>
+          <Text style={farmStyles.longValue}>{farmProfile.farm_bio}</Text>
+        </View>
+      ) : null}
+
+      {isOwner ? (
+        <Pressable
+          accessibilityRole="button"
+          disabled={deleting}
+          onPress={onDelete}
+          style={[
+            farmStyles.deleteButton,
+            deleting && farmStyles.buttonDisabled,
+          ]}
+        >
+          {deleting ? (
+            <ActivityIndicator color="#FFFFFF" />
+          ) : (
+            <Text style={farmStyles.deleteButtonText}>Delete Farm</Text>
+          )}
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}
+
+export default function FarmProfileScreen() {
+  const { farmId } = useLocalSearchParams<{ farmId: string }>();
+  const { user } = useAuth();
+  const router = useRouter();
+  const [farmProfile, setFarmProfile] = useState<FarmProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [deleting, setDeleting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchFarmProfileById(farmId)
+      .then(setFarmProfile)
+      .catch((error) => setErrorMessage(error.message))
+      .finally(() => setLoading(false));
+  }, [farmId]);
+
+  const handleDelete = () => {
+    Alert.alert(
+      "Delete Farm",
+      "This will permanently remove your farm profile. This cannot be undone.",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Delete",
+          style: "destructive",
+          onPress: async () => {
+            if (!user) return;
+            try {
+              setDeleting(true);
+              await deleteFarmProfile(user.id);
+              router.replace("/");
+            } catch (error) {
+              setErrorMessage(
+                error instanceof Error
+                  ? error.message
+                  : "Unable to delete farm profile.",
+              );
+              setDeleting(false);
+            }
+          },
+        },
+      ],
+    );
+  };
+
+  if (loading) {
+    return (
+      <SafeAreaView style={farmStyles.page}>
+        <ActivityIndicator color="#2F6A3E" />
+      </SafeAreaView>
+    );
+  }
+
+  if (errorMessage || !farmProfile) {
+    return (
+      <SafeAreaView style={farmStyles.page}>
+        <Text style={farmStyles.errorText}>
+          {errorMessage ?? "Farm not found."}
+        </Text>
+      </SafeAreaView>
+    );
+  }
+
+  const isOwner = user?.id === farmProfile.user_id;
+
+  return (
+    <SafeAreaView style={farmStyles.page}>
+      <ScrollView
+        contentContainerStyle={farmStyles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        <FarmHeroCard farmProfile={farmProfile} />
+        <FarmDetailsPanel
+          deleting={deleting}
+          farmProfile={farmProfile}
+          isOwner={isOwner}
+          onEdit={() => router.replace("/farm/edit")}
+          onDelete={handleDelete}
+        />
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/src/app/farm/edit.tsx
+++ b/src/app/farm/edit.tsx
@@ -1,0 +1,157 @@
+import { useRouter } from "expo-router";
+import { useEffect, useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import {
+  fetchFarmProfileByUserId,
+  upsertFarmProfile,
+} from "../../lib/farmProfiles";
+import { useAuth } from "../../providers/auth-provider";
+import { farmStyles } from "../../styles/farm-styles";
+
+export default function FarmEditScreen() {
+  const { user, profile } = useAuth();
+  const router = useRouter();
+
+  const [farmName, setFarmName] = useState(""); // State for farm name
+  const [farmBio, setFarmBio] = useState(""); // New state for farm bio
+  const [farmLocation, setFarmLocation] = useState(""); // New state for farm location
+  const [isExisting, setIsExisting] = useState(false); // Track if we're editing an existing profile or creating a new one
+  const [loading, setLoading] = useState(true); // Loading state for fetching existing profile
+  const [saving, setSaving] = useState(false); // Saving state for when the user submits the form
+  const [errorMessage, setErrorMessage] = useState<string | null>(null); // State for error messages
+
+  // Fetch existing farm profile
+  useEffect(() => {
+    if (!user) return;
+
+    fetchFarmProfileByUserId(user.id)
+      .then((existing) => {
+        if (existing) {
+          setFarmName(existing.farm_name);
+          setFarmBio(existing.farm_bio ?? "");
+          setFarmLocation(existing.farm_location ?? "");
+          setIsExisting(true);
+        }
+      })
+      .catch((error) => setErrorMessage(error.message))
+      .finally(() => setLoading(false));
+  }, [user]);
+
+  // Handle save action
+  const handleSave = async () => {
+    if (!user) return;
+    try {
+      setSaving(true);
+      setErrorMessage(null);
+      const saved = await upsertFarmProfile(
+        user.id,
+        farmName,
+        farmBio,
+        farmLocation,
+      );
+      router.replace(`/farm/${saved.id}`);
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Unable to save farm profile.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Only allow farmers to access this screen
+  if (profile?.role !== "farmer") {
+    return (
+      <SafeAreaView style={farmStyles.page}>
+        <Text style={farmStyles.errorText}>
+          Only farmers can edit a farm profile.
+        </Text>
+      </SafeAreaView>
+    );
+  }
+
+  // Show loading state while fetching existing profile
+  if (loading) {
+    return (
+      <SafeAreaView style={farmStyles.page}>
+        <ActivityIndicator color="#2F6A3E" />
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={farmStyles.page}>
+      <ScrollView contentContainerStyle={farmStyles.scrollContent}>
+        <View style={farmStyles.card}>
+          <Text style={farmStyles.title}>
+            {isExisting ? "Edit farm profile" : "Create farm profile"}
+          </Text>
+
+          <View style={farmStyles.fieldGroup}>
+            <Text style={farmStyles.label}>Farm name</Text>
+            <TextInput
+              onChangeText={setFarmName}
+              placeholder="Your farm's name"
+              placeholderTextColor="#7A867D"
+              style={farmStyles.input}
+              value={farmName}
+            />
+          </View>
+
+          <View style={farmStyles.fieldGroup}>
+            <Text style={farmStyles.label}>Location</Text>
+            <TextInput
+              onChangeText={setFarmLocation}
+              placeholder="Town or area"
+              placeholderTextColor="#7A867D"
+              style={farmStyles.input}
+              value={farmLocation}
+            />
+          </View>
+
+          <View style={farmStyles.fieldGroup}>
+            <Text style={farmStyles.label}>Bio</Text>
+            <TextInput
+              multiline
+              onChangeText={setFarmBio}
+              placeholder="Tell customers about your farm"
+              placeholderTextColor="#7A867D"
+              style={[farmStyles.input, farmStyles.textArea]}
+              textAlignVertical="top"
+              value={farmBio}
+            />
+          </View>
+
+          {errorMessage ? (
+            <Text style={farmStyles.errorText}>{errorMessage}</Text>
+          ) : null}
+
+          <Pressable
+            disabled={saving}
+            onPress={handleSave}
+            style={[
+              farmStyles.primaryButton,
+              saving && farmStyles.buttonDisabled,
+            ]}
+          >
+            {saving ? (
+              <ActivityIndicator color="#FFFFFF" />
+            ) : (
+              <Text style={farmStyles.primaryButtonText}>
+                {isExisting ? "Save changes" : "Create farm profile"}
+              </Text>
+            )}
+          </Pressable>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -8,7 +8,7 @@ import {
   useWindowDimensions,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-
+import { useFarmProfile } from "../hooks/useFarmProfile";
 import { isSupabaseConfigured, supabaseConfigError } from "../lib/supabase";
 import { useAuth } from "../providers/auth-provider";
 
@@ -103,6 +103,7 @@ const saturdayMarkets = [
 export default function Index() {
   const { width } = useWindowDimensions();
   const { session, user } = useAuth();
+  const { farmProfile } = useFarmProfile(user?.id);
   const isWide = width >= 940;
   const isMedium = width >= 720;
   const phoneWidth = width < 390 ? 250 : 286;
@@ -308,12 +309,24 @@ export default function Index() {
               </Text>
               <View style={styles.heroActionRow}>
                 {session ? (
-                  <Link
-                    href={"/account" as Href}
-                    style={[styles.ctaLink, styles.ctaLinkPrimary]}
-                  >
-                    Open account
-                  </Link>
+                  <>
+                    <Link
+                      href={"/account" as Href}
+                      style={[styles.ctaLink, styles.ctaLinkPrimary]}
+                    >
+                      Open account
+                    </Link>
+                    <Link
+                      href={
+                        farmProfile
+                          ? (`/farm/${farmProfile.id}` as Href)
+                          : ("/farm/edit" as Href)
+                      }
+                      style={[styles.ctaLink, styles.ctaLinkPrimary]}
+                    >
+                      {farmProfile ? "Farm management" : "Create a farm"}
+                    </Link>
+                  </>
                 ) : (
                   <>
                     <Link

--- a/src/components/FarmHeroCard.tsx
+++ b/src/components/FarmHeroCard.tsx
@@ -1,0 +1,33 @@
+import { Text, View } from "react-native";
+
+import { type FarmProfile } from "../lib/farmProfiles";
+import { farmStyles } from "../styles/farm-styles";
+
+function farmInitials(name: string): string {
+  return (
+    name
+      .split(" ")
+      .slice(0, 2)
+      .map((w) => w[0].toUpperCase())
+      .join("") || "FC"
+  );
+}
+
+export function FarmHeroCard({ farmProfile }: { farmProfile: FarmProfile }) {
+  return (
+    <View style={farmStyles.heroCard}>
+      <View style={farmStyles.avatarCircle}>
+        <Text style={farmStyles.avatarText}>
+          {farmInitials(farmProfile.farm_name)}
+        </Text>
+      </View>
+      <View style={farmStyles.heroCopy}>
+        <Text style={farmStyles.eyebrow}>Farm profile</Text>
+        <Text style={farmStyles.heroTitle}>{farmProfile.farm_name}</Text>
+        {farmProfile.farm_location ? (
+          <Text style={farmStyles.heroBody}>{farmProfile.farm_location}</Text>
+        ) : null}
+      </View>
+    </View>
+  );
+}

--- a/src/hooks/useFarmProfile.ts
+++ b/src/hooks/useFarmProfile.ts
@@ -1,0 +1,40 @@
+/**
+ * useFarmProfile
+ *
+ * Fetches the farm profile for a given user ID.
+ * Returns null if the user has no farm profile yet.
+ *
+ * Use this hook in any screen that needs farm profile data for the current user.
+ *
+ * Usage:
+ *   const { farmProfile, loading } = useFarmProfile(user?.id);
+ *
+ * Examples:
+ *   // Access farm data
+ *   <Text>{farmProfile.farm_name}</Text>
+ */
+import { useEffect, useState } from "react";
+
+import {
+  type FarmProfile,
+  fetchFarmProfileByUserId,
+} from "../lib/farmProfiles";
+
+export function useFarmProfile(userId: string | undefined): {
+  farmProfile: FarmProfile | null;
+  loading: boolean;
+} {
+  const [farmProfile, setFarmProfile] = useState<FarmProfile | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!userId) return setFarmProfile(null);
+    setLoading(true);
+    fetchFarmProfileByUserId(userId)
+      .then(setFarmProfile)
+      .catch(() => setFarmProfile(null))
+      .finally(() => setLoading(false));
+  }, [userId]);
+
+  return { farmProfile, loading };
+}

--- a/src/lib/farmProfiles.ts
+++ b/src/lib/farmProfiles.ts
@@ -1,0 +1,81 @@
+import { supabase } from "./supabase";
+
+export type FarmProfile = {
+  id: string;
+  user_id: string;
+  farm_name: string;
+  farm_bio: string | null;
+  farm_location: string | null;
+  farm_profile_picture_url: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export async function fetchFarmProfileByUserId(
+  userId: string,
+): Promise<FarmProfile | null> {
+  if (!supabase) throw new Error("Supabase is not configured.");
+
+  const { data, error } = await supabase
+    .from("farm_profiles")
+    .select("*")
+    .eq("user_id", userId)
+    .maybeSingle<FarmProfile>();
+
+  if (error) throw error;
+  return data;
+}
+
+export async function fetchFarmProfileById(
+  farmId: string,
+): Promise<FarmProfile | null> {
+  if (!supabase) throw new Error("Supabase is not configured.");
+
+  const { data, error } = await supabase
+    .from("farm_profiles")
+    .select("*")
+    .eq("id", farmId)
+    .maybeSingle<FarmProfile>();
+
+  if (error) throw error;
+  return data;
+}
+
+export async function upsertFarmProfile(
+  userId: string,
+  farmName: string,
+  farmBio: string,
+  farmLocation: string,
+): Promise<FarmProfile> {
+  if (!supabase) throw new Error("Supabase is not configured.");
+
+  const { data, error } = await supabase
+    .from("farm_profiles")
+    .upsert(
+      {
+        user_id: userId,
+        farm_name: farmName.trim(),
+        farm_bio: farmBio.trim() || null,
+        farm_location: farmLocation.trim() || null,
+        farm_profile_picture_url: null, // Image uploads handled separately, not yet implemented
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "user_id" },
+    )
+    .select("*")
+    .single<FarmProfile>();
+
+  if (error) throw error;
+  return data;
+}
+
+export async function deleteFarmProfile(userId: string): Promise<void> {
+  if (!supabase) throw new Error("Supabase is not configured.");
+
+  const { error } = await supabase
+    .from("farm_profiles")
+    .delete()
+    .eq("user_id", userId);
+
+  if (error) throw error;
+}

--- a/src/styles/farm-styles.tsx
+++ b/src/styles/farm-styles.tsx
@@ -1,0 +1,186 @@
+import { StyleSheet } from "react-native";
+
+// AI Generated Code - Whole File
+const shadow = {
+  boxShadow: "0px 18px 40px rgba(26, 41, 30, 0.08)",
+} as const;
+
+export const farmStyles = StyleSheet.create({
+  page: {
+    flex: 1,
+    backgroundColor: "#F4F5EF",
+  },
+  scrollContent: {
+    gap: 16,
+    paddingHorizontal: 18,
+    paddingVertical: 24,
+  },
+  heroCard: {
+    backgroundColor: "#21432D",
+    borderRadius: 28,
+    gap: 16,
+    padding: 22,
+    ...shadow,
+  },
+  avatarCircle: {
+    alignItems: "center",
+    backgroundColor: "#F3E6BB",
+    borderRadius: 999,
+    height: 64,
+    justifyContent: "center",
+    width: 64,
+  },
+  avatarText: {
+    color: "#21432D",
+    fontSize: 22,
+    fontWeight: "800",
+  },
+  heroCopy: {
+    gap: 6,
+  },
+  eyebrow: {
+    color: "#B9D1BF",
+    fontSize: 12,
+    fontWeight: "700",
+    letterSpacing: 0.4,
+    textTransform: "uppercase",
+  },
+  heroTitle: {
+    color: "#FFFFFF",
+    fontSize: 28,
+    fontWeight: "800",
+    letterSpacing: -0.7,
+  },
+  heroBody: {
+    color: "#D8E2DB",
+    fontSize: 15,
+    lineHeight: 22,
+  },
+  panel: {
+    backgroundColor: "#FFFFFF",
+    borderColor: "#DFE4DB",
+    borderRadius: 24,
+    borderWidth: 1,
+    gap: 14,
+    padding: 18,
+    ...shadow,
+  },
+  sectionHeader: {
+    gap: 12,
+  },
+  panelTitle: {
+    color: "#182019",
+    fontSize: 18,
+    fontWeight: "800",
+  },
+  readonlyGrid: {
+    gap: 12,
+  },
+  readonlyItem: {
+    backgroundColor: "#F7FBF5",
+    borderColor: "#D7E2D3",
+    borderRadius: 18,
+    borderWidth: 1,
+    gap: 4,
+    padding: 14,
+  },
+  readonlyLabel: {
+    color: "#5D6A60",
+    fontSize: 12,
+    fontWeight: "700",
+    letterSpacing: 0.3,
+    textTransform: "uppercase",
+  },
+  readonlyMeta: {
+    color: "#445148",
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  textBlock: {
+    gap: 6,
+  },
+  longValue: {
+    color: "#213025",
+    fontSize: 15,
+    lineHeight: 22,
+  },
+  inlineButton: {
+    alignSelf: "flex-start",
+    backgroundColor: "#EEF5EB",
+    borderRadius: 999,
+    paddingHorizontal: 14,
+    paddingVertical: 9,
+  },
+  inlineButtonText: {
+    color: "#214C2D",
+    fontSize: 13,
+    fontWeight: "700",
+  },
+  card: {
+    backgroundColor: "#FFFFFF",
+    borderColor: "#DDE4D9",
+    borderRadius: 24,
+    borderWidth: 1,
+    gap: 14,
+    padding: 18,
+  },
+  title: {
+    color: "#182019",
+    fontSize: 22,
+    fontWeight: "800",
+  },
+  fieldGroup: {
+    gap: 8,
+  },
+  label: {
+    color: "#182019",
+    fontSize: 14,
+    fontWeight: "700",
+  },
+  input: {
+    backgroundColor: "#FFFFFF",
+    borderColor: "#DDE4D9",
+    borderRadius: 18,
+    borderWidth: 1,
+    color: "#182019",
+    fontSize: 15,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+  },
+  textArea: {
+    minHeight: 120,
+  },
+  primaryButton: {
+    alignItems: "center",
+    backgroundColor: "#2F6A3E",
+    borderRadius: 18,
+    justifyContent: "center",
+    minHeight: 52,
+  },
+  primaryButtonText: {
+    color: "#FFFFFF",
+    fontSize: 15,
+    fontWeight: "700",
+  },
+  buttonDisabled: {
+    opacity: 0.7,
+  },
+  deleteButton: {
+    alignItems: "center",
+    backgroundColor: "#7A2A20",
+    borderRadius: 18,
+    justifyContent: "center",
+    minHeight: 52,
+    marginTop: 4,
+  },
+  deleteButtonText: {
+    color: "#FFFFFF",
+    fontSize: 15,
+    fontWeight: "700",
+  },
+  errorText: {
+    color: "#9C5B4D",
+    fontSize: 14,
+    padding: 18,
+  },
+});


### PR DESCRIPTION
## Farm Profile — View, Edit & Delete

Closes #22

### What's in this PR

Farmers now have a dedicated profile screen for their **farms**. From the landing page, a signed-in farmer sees a **Farm management** button (or **Create a farm** if they don't have one yet) in the Account Access section. That button routes to either the view or the edit/create screen. The styling mimics the account section of the app.

**View screen (`/farm/[farmId]`)**
- Hero card with farm name initials, name, and location
- Details panel showing created and last updated timestamps, and the farm bio
- Inline **Edit farm profile** button visible only to the farm owner
- **Delete Farm** button with a confirmation alert, owner-only

**Edit screen (`/farm/edit`)**
- Handles both creation and editing in one screen
- After saving, navigates back to the farm view with a clean stack (back → index)

### Structure
- `FarmHeroCard` extracted as a reusable component in `src/components/`
- `useFarmProfile` hook in `src/hooks/` for any screen that needs farm profile data by user ID
- All farm styles centralised in `farm-styles.tsx`

### Screenshots

| | |
|---|---|
| <img width="406" height="936" alt="1" src="https://github.com/user-attachments/assets/a2540277-6a9c-48c1-bd69-b36979997692" /> | <img width="408" height="936" alt="2" src="https://github.com/user-attachments/assets/68366e64-ce5f-493d-b567-07b0a676ceb6" /> |
| <img width="405" height="937" alt="3" src="https://github.com/user-attachments/assets/846ed3af-2493-4dca-8786-95d360625757" /> | <img width="405" height="937" alt="4" src="https://github.com/user-attachments/assets/813dd36a-2677-4b86-a06f-0393feea5564" /> |
