### PR TITLE
Feature/market day management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@react-native-async-storage/async-storage": "2.2.0",
+        "@react-native-community/datetimepicker": "8.6.0",
         "@react-navigation/bottom-tabs": "^7.15.5",
         "@react-navigation/elements": "^2.9.10",
         "@react-navigation/native": "^7.1.33",
@@ -3423,6 +3424,29 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
+    "node_modules/@react-native-community/datetimepicker": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.6.0.tgz",
+      "integrity": "sha512-yxPSqNfxgpGaqHQIpatqe6ykeBdU/1pdsk/G3x01mY2bpTflLpmVTLqFSJYd3MiZzxNZcMs/j1dQakUczSjcYA==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": ">=52.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-windows": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "react-native-windows": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native/assets-registry": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1564,9 +1564,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1652,9 +1652,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1754,14 +1754,14 @@
       }
     },
     "node_modules/@expo/config": {
-      "version": "55.0.10",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-55.0.10.tgz",
-      "integrity": "sha512-qCHxo9H1ZoeW+y0QeMtVZ3JfGmumpGrgUFX60wLWMarraoQZSe47ZUm9kJSn3iyoPjUtUNanO3eXQg+K8k4rag==",
+      "version": "55.0.12",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-55.0.12.tgz",
+      "integrity": "sha512-qVih0IrjupykH/yAUilZqW1RCpqm8TKG8XJabji2VHI1LstGqw0NJAsBjX927yns08u/fFJTwOsB4PYOoq1HiA==",
       "license": "MIT",
       "dependencies": {
         "@expo/config-plugins": "~55.0.7",
         "@expo/config-types": "^55.0.5",
-        "@expo/json-file": "^10.0.12",
+        "@expo/json-file": "^10.0.13",
         "@expo/require-utils": "^55.0.3",
         "deepmerge": "^4.3.1",
         "getenv": "^2.0.0",
@@ -1950,9 +1950,9 @@
       }
     },
     "node_modules/@expo/json-file": {
-      "version": "10.0.12",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.12.tgz",
-      "integrity": "sha512-inbDycp1rMAelAofg7h/mMzIe+Owx6F7pur3XdQ3EPTy00tme+4P6FWgHKUcjN8dBSrnbRNpSyh5/shzHyVCyQ==",
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.13.tgz",
+      "integrity": "sha512-pX/XjQn7tgNw6zuuV2ikmegmwe/S7uiwhrs2wXrANMkq7ozrA+JcZwgW9Q/8WZgciBzfAhNp5hnackHcrmapQA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -2671,9 +2671,9 @@
       "license": "MIT"
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -3558,9 +3558,9 @@
       "license": "MIT"
     },
     "node_modules/@react-native/codegen/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4855,9 +4855,9 @@
       ]
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -5040,9 +5040,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -5651,9 +5651,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -7173,9 +7173,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7260,9 +7260,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7345,9 +7345,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10186,9 +10186,9 @@
       "license": "MIT"
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -10394,14 +10394,14 @@
       }
     },
     "node_modules/jest-expo": {
-      "version": "55.0.11",
-      "resolved": "https://registry.npmjs.org/jest-expo/-/jest-expo-55.0.11.tgz",
-      "integrity": "sha512-dwOrmui4nYFuu6P3pMFXdJ9EzwpLsfTQJk4Fp3wuOmfredAgqOihljHUJwpzG1aGbSQc1+xhGgE7SmK21L4svw==",
+      "version": "55.0.13",
+      "resolved": "https://registry.npmjs.org/jest-expo/-/jest-expo-55.0.13.tgz",
+      "integrity": "sha512-HMI2IDOsnoQnKbUNPPLuM+XDQ8QD+QUVP7ETeQWYeq87SUZWKYV+vMwwtRiZFawGnYEqYx0qj8iL0RzKXlFNWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~55.0.10",
-        "@expo/json-file": "^10.0.12",
+        "@expo/config": "~55.0.12",
+        "@expo/json-file": "^10.0.13",
         "@jest/create-cache-key-function": "^29.2.1",
         "@jest/globals": "^29.2.1",
         "babel-jest": "^29.2.1",
@@ -10756,9 +10756,9 @@
       "license": "MIT"
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -10951,9 +10951,9 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -11735,9 +11735,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -12255,9 +12255,9 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -12500,9 +12500,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -13096,9 +13096,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -13828,9 +13828,9 @@
       "license": "MIT"
     },
     "node_modules/react-native/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -14247,9 +14247,9 @@
       "license": "MIT"
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -15324,9 +15324,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@react-native-community/datetimepicker": "8.6.0",
     "@react-navigation/bottom-tabs": "^7.15.5",
     "@react-navigation/elements": "^2.9.10",
     "@react-navigation/native": "^7.1.33",

--- a/src/app/account.tsx
+++ b/src/app/account.tsx
@@ -382,6 +382,11 @@ function FarmerProfileView() {
         fields are designed. This customer profile form is intentionally not
         shown here.
       </Text>
+      <Link href={"/dashboard" as Href} asChild>
+        <Pressable accessibilityRole="button" style={styles.primaryButton}>
+          <Text style={styles.primaryButtonText}>Open dashboard</Text>
+        </Pressable>
+      </Link>
     </View>
   );
 }
@@ -621,6 +626,22 @@ const styles = StyleSheet.create({
     color: "#5D6A60",
     fontSize: 14,
     lineHeight: 21,
+  },
+  dashboardButtonRow: {
+    marginTop: 15,
+  },
+  dashboardButton: {
+    alignItems: "center",
+    backgroundColor: "#2F6A3E",
+    borderRadius: 18,
+    justifyContent: "center",
+    minHeight: 48,
+    paddingHorizontal: 18,
+  },
+  dashboardButtonText: {
+    color: "#FFFFFF",
+    fontSize: 15,
+    fontWeight: "700",
   },
   sectionHeader: {
     gap: 12,

--- a/src/app/account.tsx
+++ b/src/app/account.tsx
@@ -382,7 +382,7 @@ function FarmerProfileView() {
         fields are designed. This customer profile form is intentionally not
         shown here.
       </Text>
-      <Link href={"/dashboard" as Href} asChild>
+      <Link href={"/farmer_dashboard" as Href} asChild>
         <Pressable accessibilityRole="button" style={styles.primaryButton}>
           <Text style={styles.primaryButtonText}>Open dashboard</Text>
         </Pressable>

--- a/src/app/dashboard/index.tsx
+++ b/src/app/dashboard/index.tsx
@@ -1,0 +1,100 @@
+import { Link, type Href } from "expo-router";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { useAuth } from "../../providers/auth-provider";
+
+export default function DashboardScreen() {
+  const { profile } = useAuth();
+  const isFarmer = profile?.role === "farmer";
+
+  return (
+    <SafeAreaView style={styles.page}>
+      <ScrollView
+        contentContainerStyle={styles.content}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={styles.heroCard}>
+          <Text style={styles.heroTitle}>Farmer dashboard</Text>
+          <Text style={styles.heroBody}>
+            {isFarmer
+              ? "Manage your market days, pickup windows, and produce inventory from here."
+              : "This area is intended for farmer accounts. If you need access, update your profile role."}
+          </Text>
+        </View>
+
+        {isFarmer ? (
+          <View style={styles.panel}>
+            <Text style={styles.panelTitle}>Ready for launch</Text>
+            <Text style={styles.panelBody}>
+              The dashboard page is in place. Add market-day and pickup
+              management components next.
+            </Text>
+          </View>
+        ) : null}
+
+        <View style={styles.footerRow}>
+          <Link href={'/account' as Href} style={styles.footerLink}>
+            Back to profile
+          </Link>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  page: {
+    flex: 1,
+    backgroundColor: "#F6F7F3",
+  },
+  content: {
+    padding: 24,
+    gap: 20,
+  },
+  heroCard: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 24,
+    padding: 24,
+    shadowColor: "#000",
+    shadowOpacity: 0.05,
+    shadowRadius: 20,
+    elevation: 4,
+  },
+  heroTitle: {
+    fontSize: 28,
+    fontWeight: "800",
+    color: "#182019",
+    marginBottom: 12,
+  },
+  heroBody: {
+    fontSize: 16,
+    lineHeight: 24,
+    color: "#3E4C42",
+  },
+  panel: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 24,
+    padding: 20,
+  },
+  panelTitle: {
+    fontSize: 20,
+    fontWeight: "700",
+    color: "#182019",
+    marginBottom: 8,
+  },
+  panelBody: {
+    fontSize: 15,
+    lineHeight: 22,
+    color: "#4D5B50",
+  },
+  footerRow: {
+    alignItems: "center",
+    marginTop: 16,
+  },
+  footerLink: {
+    color: "#2F6A3E",
+    fontWeight: "700",
+    fontSize: 15,
+  },
+});

--- a/src/app/farmer_dashboard/index.tsx
+++ b/src/app/farmer_dashboard/index.tsx
@@ -4,7 +4,6 @@ import { SafeAreaView } from "react-native-safe-area-context";
 
 import { useAuth } from "../../providers/auth-provider";
 
-
 export default function DashboardScreen() {
   const { profile } = useAuth();
   const isFarmer = profile?.role === "farmer";
@@ -31,20 +30,19 @@ export default function DashboardScreen() {
               The dashboard page is in place. Add market-day and pickup
               management components next.
             </Text>
-            <Link href={'/farmer_dashboard/market' as Href} style={styles.panelButton}>
-              <Text style={styles.panelButtonText}>Go to Market Management</Text>
+            <Link
+              href={"/farmer_dashboard/market" as Href}
+              style={styles.panelButton}
+            >
+              <Text style={styles.panelButtonText}>
+                Go to Market Management
+              </Text>
             </Link>
           </View>
         ) : null}
 
         <View style={styles.footerRow}>
-          <Link href={'/market' as Href} style={styles.footerLink}>
-            Back to profile
-          </Link>
-        </View>
-
-        <View style={styles.footerRow}>
-          <Link href={'/account' as Href} style={styles.footerLink}>
+          <Link href={"/account" as Href} style={styles.footerLink}>
             Back to profile
           </Link>
         </View>

--- a/src/app/farmer_dashboard/index.tsx
+++ b/src/app/farmer_dashboard/index.tsx
@@ -4,6 +4,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 
 import { useAuth } from "../../providers/auth-provider";
 
+
 export default function DashboardScreen() {
   const { profile } = useAuth();
   const isFarmer = profile?.role === "farmer";
@@ -30,8 +31,17 @@ export default function DashboardScreen() {
               The dashboard page is in place. Add market-day and pickup
               management components next.
             </Text>
+            <Link href={'/farmer_dashboard/market' as Href} style={styles.panelButton}>
+              <Text style={styles.panelButtonText}>Go to Market Management</Text>
+            </Link>
           </View>
         ) : null}
+
+        <View style={styles.footerRow}>
+          <Link href={'/market' as Href} style={styles.footerLink}>
+            Back to profile
+          </Link>
+        </View>
 
         <View style={styles.footerRow}>
           <Link href={'/account' as Href} style={styles.footerLink}>
@@ -87,6 +97,19 @@ const styles = StyleSheet.create({
     fontSize: 15,
     lineHeight: 22,
     color: "#4D5B50",
+  },
+  panelButton: {
+    marginTop: 16,
+    backgroundColor: "#2F6A3E",
+    borderRadius: 16,
+    paddingVertical: 14,
+    paddingHorizontal: 18,
+    alignItems: "center",
+  },
+  panelButtonText: {
+    color: "#FFFFFF",
+    fontSize: 15,
+    fontWeight: "700",
   },
   footerRow: {
     alignItems: "center",

--- a/src/app/farmer_dashboard/market.tsx
+++ b/src/app/farmer_dashboard/market.tsx
@@ -1,17 +1,20 @@
 import { supabase } from "@/lib/supabase";
-import DateTimePicker, { DateTimePickerEvent } from "@react-native-community/datetimepicker";
+import DateTimePicker, {
+  DateTimePickerEvent,
+} from "@react-native-community/datetimepicker";
+import { useRouter } from "expo-router";
 import React, { useCallback, useEffect, useState } from "react";
 import {
-    ActivityIndicator,
-    Alert,
-    Modal,
-    Platform,
-    ScrollView,
-    StyleSheet,
-    Text,
-    TextInput,
-    TouchableOpacity,
-    View,
+  ActivityIndicator,
+  Alert,
+  Modal,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useAuth } from "../../providers/auth-provider";
@@ -112,13 +115,31 @@ function MarketDayCard({
 
   return (
     <View style={[styles.panel, isPast && { opacity: 0.6 }]}>
-      <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "flex-start" }}>
+      <View
+        style={{
+          flexDirection: "row",
+          justifyContent: "space-between",
+          alignItems: "flex-start",
+        }}
+      >
         <View style={{ flex: 1, marginRight: 10, gap: 2 }}>
           <Text style={styles.panelTitle}>{formatDate(item.date)}</Text>
-          <Text style={styles.panelBody}>{formatTime(item.start_time)} – {formatTime(item.end_time)}</Text>
+          <Text style={styles.panelBody}>
+            {formatTime(item.start_time)} – {formatTime(item.end_time)}
+          </Text>
         </View>
-        <View style={[styles.inlineButton, { backgroundColor: STATUS_COLOR[item.status] + "1A" }]}>
-          <Text style={[styles.inlineButtonText, { color: STATUS_COLOR[item.status] }]}>
+        <View
+          style={[
+            styles.inlineButton,
+            { backgroundColor: STATUS_COLOR[item.status] + "1A" },
+          ]}
+        >
+          <Text
+            style={[
+              styles.inlineButtonText,
+              { color: STATUS_COLOR[item.status] },
+            ]}
+          >
             {STATUS_LABEL[item.status]}
           </Text>
         </View>
@@ -150,7 +171,9 @@ function MarketDayCard({
             onPress={() => onDelete(item.id)}
             activeOpacity={0.7}
           >
-            <Text style={[styles.secondaryButtonText, { color: "#9C5B4D" }]}>Cancel</Text>
+            <Text style={[styles.secondaryButtonText, { color: "#9C5B4D" }]}>
+              Cancel
+            </Text>
           </TouchableOpacity>
         </View>
       )}
@@ -199,9 +222,12 @@ function MarketDayModal({
   }
 
   function pickerValue(): Date {
-    if (activePicker === "date") return form.date ? strToDate(form.date) : new Date();
-    if (activePicker === "start_time") return form.start_time ? strToTime(form.start_time) : strToTime("08:00");
-    if (activePicker === "end_time") return form.end_time ? strToTime(form.end_time) : strToTime("13:00");
+    if (activePicker === "date")
+      return form.date ? strToDate(form.date) : new Date();
+    if (activePicker === "start_time")
+      return form.start_time ? strToTime(form.start_time) : strToTime("08:00");
+    if (activePicker === "end_time")
+      return form.end_time ? strToTime(form.end_time) : strToTime("13:00");
     return new Date();
   }
 
@@ -235,15 +261,25 @@ function MarketDayModal({
             {initial?.date ? "Edit Market Day" : "New Market Day"}
           </Text>
 
-          <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={{ gap: 12 }}>
+          <ScrollView
+            showsVerticalScrollIndicator={false}
+            contentContainerStyle={{ gap: 12 }}
+          >
             <View style={styles.fieldGroup}>
               <Text style={styles.label}>Date</Text>
               <TouchableOpacity
                 style={[styles.input, { justifyContent: "center" }]}
-                onPress={() => setActivePicker(activePicker === "date" ? null : "date")}
+                onPress={() =>
+                  setActivePicker(activePicker === "date" ? null : "date")
+                }
                 activeOpacity={0.7}
               >
-                <Text style={{ color: form.date ? "#182019" : "#B0BAB4", fontSize: 15 }}>
+                <Text
+                  style={{
+                    color: form.date ? "#182019" : "#B0BAB4",
+                    fontSize: 15,
+                  }}
+                >
                   {form.date ? formatDate(form.date) : "Select a date"}
                 </Text>
               </TouchableOpacity>
@@ -264,10 +300,19 @@ function MarketDayModal({
                 <Text style={styles.label}>Start time</Text>
                 <TouchableOpacity
                   style={[styles.input, { justifyContent: "center" }]}
-                  onPress={() => setActivePicker(activePicker === "start_time" ? null : "start_time")}
+                  onPress={() =>
+                    setActivePicker(
+                      activePicker === "start_time" ? null : "start_time",
+                    )
+                  }
                   activeOpacity={0.7}
                 >
-                  <Text style={{ color: form.start_time ? "#182019" : "#B0BAB4", fontSize: 15 }}>
+                  <Text
+                    style={{
+                      color: form.start_time ? "#182019" : "#B0BAB4",
+                      fontSize: 15,
+                    }}
+                  >
                     {form.start_time ? formatTime(form.start_time) : "08:00"}
                   </Text>
                 </TouchableOpacity>
@@ -287,10 +332,19 @@ function MarketDayModal({
                 <Text style={styles.label}>End time</Text>
                 <TouchableOpacity
                   style={[styles.input, { justifyContent: "center" }]}
-                  onPress={() => setActivePicker(activePicker === "end_time" ? null : "end_time")}
+                  onPress={() =>
+                    setActivePicker(
+                      activePicker === "end_time" ? null : "end_time",
+                    )
+                  }
                   activeOpacity={0.7}
                 >
-                  <Text style={{ color: form.end_time ? "#182019" : "#B0BAB4", fontSize: 15 }}>
+                  <Text
+                    style={{
+                      color: form.end_time ? "#182019" : "#B0BAB4",
+                      fontSize: 15,
+                    }}
+                  >
                     {form.end_time ? formatTime(form.end_time) : "13:00"}
                   </Text>
                 </TouchableOpacity>
@@ -343,7 +397,11 @@ function MarketDayModal({
               <Text style={styles.secondaryButtonText}>Cancel</Text>
             </TouchableOpacity>
             <TouchableOpacity
-              style={[styles.primaryButton, { flex: 1 }, saving && styles.buttonDisabled]}
+              style={[
+                styles.primaryButton,
+                { flex: 1 },
+                saving && styles.buttonDisabled,
+              ]}
               onPress={() => validate() && onSave(form)}
               activeOpacity={0.7}
               disabled={saving}
@@ -363,6 +421,7 @@ function MarketDayModal({
 
 export default function MarketDaysScreen() {
   const { user } = useAuth();
+  const router = useRouter();
   const [marketDays, setMarketDays] = useState<MarketDay[]>([]);
   const [filter, setFilter] = useState<Filter>("upcoming");
   const [loading, setLoading] = useState(true);
@@ -370,7 +429,9 @@ export default function MarketDaysScreen() {
   const [error, setError] = useState<string | null>(null);
   const [modalVisible, setModalVisible] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
-  const [formInitial, setFormInitial] = useState<typeof EMPTY_FORM | null>(null);
+  const [formInitial, setFormInitial] = useState<typeof EMPTY_FORM | null>(
+    null,
+  );
 
   const fetchMarketDays = useCallback(async () => {
     if (!user || !supabase) return;
@@ -409,7 +470,7 @@ export default function MarketDaysScreen() {
     .sort((a, b) =>
       filter === "past"
         ? b.date.localeCompare(a.date)
-        : a.date.localeCompare(b.date)
+        : a.date.localeCompare(b.date),
     );
 
   function openCreate() {
@@ -496,32 +557,51 @@ export default function MarketDaysScreen() {
             }
           },
         },
-      ]
+      ],
     );
   }
 
   return (
     <SafeAreaView style={styles.page}>
-      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
         <View style={styles.heroCard}>
           <View style={styles.heroCopy}>
             <Text style={styles.eyebrow}>Farmer Dashboard</Text>
             <Text style={styles.heroTitle}>Market Days</Text>
             <Text style={styles.heroBody}>
-              Schedule and manage your market appearances. Customers can see where to find you.
+              Schedule and manage your market appearances. Customers can see
+              where to find you.
             </Text>
           </View>
           {upcoming.length > 0 && (
             <View style={styles.readonlyItem}>
               <Text style={styles.readonlyLabel}>Scheduled</Text>
               <Text style={styles.readonlyValue}>
-                {upcoming.length} {upcoming.length === 1 ? "market day" : "market days"}
+                {upcoming.length}{" "}
+                {upcoming.length === 1 ? "market day" : "market days"}
               </Text>
             </View>
           )}
           <View style={styles.dashboardButtonRow}>
-            <TouchableOpacity style={styles.dashboardButton} onPress={openCreate} activeOpacity={0.8}>
+            <TouchableOpacity
+              style={styles.dashboardButton}
+              onPress={openCreate}
+              activeOpacity={0.8}
+            >
               <Text style={styles.dashboardButtonText}>+ Add Market Day</Text>
+            </TouchableOpacity>
+          </View>
+
+          <View style={styles.dashboardButtonRow}>
+            <TouchableOpacity
+              style={styles.dashboardButton}
+              onPress={() => router.back()}
+              activeOpacity={0.8}
+            >
+              <Text style={styles.dashboardButtonText}>Back to Dashboard</Text>
             </TouchableOpacity>
           </View>
         </View>
@@ -531,11 +611,19 @@ export default function MarketDaysScreen() {
             {(["upcoming", "past", "all"] as Filter[]).map((f) => (
               <TouchableOpacity
                 key={f}
-                style={[styles.inlineButton, filter === f && styles.optionCardActive]}
+                style={[
+                  styles.inlineButton,
+                  filter === f && styles.optionCardActive,
+                ]}
                 onPress={() => setFilter(f)}
                 activeOpacity={0.7}
               >
-                <Text style={[styles.inlineButtonText, filter === f && styles.optionTitleActive]}>
+                <Text
+                  style={[
+                    styles.inlineButtonText,
+                    filter === f && styles.optionTitleActive,
+                  ]}
+                >
                   {f.charAt(0).toUpperCase() + f.slice(1)}
                 </Text>
               </TouchableOpacity>
@@ -551,7 +639,10 @@ export default function MarketDaysScreen() {
         ) : error ? (
           <View style={styles.panel}>
             <Text style={styles.errorText}>{error}</Text>
-            <TouchableOpacity style={styles.inlineButton} onPress={fetchMarketDays}>
+            <TouchableOpacity
+              style={styles.inlineButton}
+              onPress={fetchMarketDays}
+            >
               <Text style={styles.inlineButtonText}>Try again</Text>
             </TouchableOpacity>
           </View>
@@ -568,7 +659,12 @@ export default function MarketDaysScreen() {
           </View>
         ) : (
           sorted.map((item) => (
-            <MarketDayCard key={item.id} item={item} onEdit={openEdit} onDelete={handleDelete} />
+            <MarketDayCard
+              key={item.id}
+              item={item}
+              onEdit={openEdit}
+              onDelete={handleDelete}
+            />
           ))
         )}
       </ScrollView>

--- a/src/app/farmer_dashboard/market.tsx
+++ b/src/app/farmer_dashboard/market.tsx
@@ -1,0 +1,889 @@
+import { supabase } from "@/lib/supabase";
+import DateTimePicker, { DateTimePickerEvent } from "@react-native-community/datetimepicker";
+import React, { useCallback, useEffect, useState } from "react";
+import {
+    ActivityIndicator,
+    Alert,
+    Modal,
+    Platform,
+    ScrollView,
+    StyleSheet,
+    Text,
+    TextInput,
+    TouchableOpacity,
+    View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useAuth } from "../../providers/auth-provider";
+
+type MarketDay = {
+  id: string;
+  farmer_id: string;
+  date: string;
+  start_time: string;
+  end_time: string;
+  location: string;
+  notes: string;
+  status: "upcoming" | "active" | "past";
+};
+
+type Filter = "all" | "upcoming" | "past";
+type PickerField = "date" | "start_time" | "end_time" | null;
+
+const today = new Date();
+
+function formatDate(dateStr: string): string {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const date = new Date(y, m - 1, d);
+  return date.toLocaleDateString("en-GB", {
+    weekday: "short",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+function formatTime(timeStr: string): string {
+  if (!timeStr) return "";
+  return timeStr.slice(0, 5);
+}
+
+function deriveStatus(dateStr: string): MarketDay["status"] {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const date = new Date(y, m - 1, d);
+  const t = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  if (date < t) return "past";
+  if (date.getTime() === t.getTime()) return "active";
+  return "upcoming";
+}
+
+function dateToStr(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+}
+
+function timeToStr(date: Date): string {
+  return `${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
+}
+
+function strToDate(dateStr: string): Date {
+  if (!dateStr) return new Date();
+  const [y, m, d] = dateStr.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+function strToTime(timeStr: string): Date {
+  const base = new Date();
+  if (!timeStr) return base;
+  const [h, m] = timeStr.split(":").map(Number);
+  base.setHours(h, m, 0, 0);
+  return base;
+}
+
+const EMPTY_FORM = {
+  date: "",
+  start_time: "",
+  end_time: "",
+  location: "",
+  notes: "",
+};
+
+const STATUS_LABEL: Record<MarketDay["status"], string> = {
+  upcoming: "Upcoming",
+  active: "Today",
+  past: "Past",
+};
+
+const STATUS_COLOR: Record<MarketDay["status"], string> = {
+  upcoming: "#2F6A3E",
+  active: "#E07B39",
+  past: "#9BA89E",
+};
+
+function MarketDayCard({
+  item,
+  onEdit,
+  onDelete,
+}: {
+  item: MarketDay;
+  onEdit: (item: MarketDay) => void;
+  onDelete: (id: string) => void;
+}) {
+  const isPast = item.status === "past";
+
+  return (
+    <View style={[styles.panel, isPast && { opacity: 0.6 }]}>
+      <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "flex-start" }}>
+        <View style={{ flex: 1, marginRight: 10, gap: 2 }}>
+          <Text style={styles.panelTitle}>{formatDate(item.date)}</Text>
+          <Text style={styles.panelBody}>{formatTime(item.start_time)} – {formatTime(item.end_time)}</Text>
+        </View>
+        <View style={[styles.inlineButton, { backgroundColor: STATUS_COLOR[item.status] + "1A" }]}>
+          <Text style={[styles.inlineButtonText, { color: STATUS_COLOR[item.status] }]}>
+            {STATUS_LABEL[item.status]}
+          </Text>
+        </View>
+      </View>
+
+      <View style={styles.readonlyItem}>
+        <Text style={styles.readonlyLabel}>Location</Text>
+        <Text style={styles.readonlyValue}>{item.location}</Text>
+      </View>
+
+      {item.notes ? (
+        <View style={styles.readonlyItem}>
+          <Text style={styles.readonlyLabel}>Notes</Text>
+          <Text style={styles.readonlyMeta}>{item.notes}</Text>
+        </View>
+      ) : null}
+
+      {!isPast && (
+        <View style={[styles.actionRow, { flexDirection: "row" }]}>
+          <TouchableOpacity
+            style={[styles.primaryButton, { flex: 1 }]}
+            onPress={() => onEdit(item)}
+            activeOpacity={0.7}
+          >
+            <Text style={styles.primaryButtonText}>Edit</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.secondaryButton, { flex: 1 }]}
+            onPress={() => onDelete(item.id)}
+            activeOpacity={0.7}
+          >
+            <Text style={[styles.secondaryButtonText, { color: "#9C5B4D" }]}>Cancel</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+    </View>
+  );
+}
+
+function MarketDayModal({
+  visible,
+  initial,
+  onSave,
+  onClose,
+  saving,
+}: {
+  visible: boolean;
+  initial: typeof EMPTY_FORM | null;
+  onSave: (form: typeof EMPTY_FORM) => void;
+  onClose: () => void;
+  saving: boolean;
+}) {
+  const [form, setForm] = useState(initial ?? EMPTY_FORM);
+  const [activePicker, setActivePicker] = useState<PickerField>(null);
+
+  useEffect(() => {
+    setForm(initial ?? EMPTY_FORM);
+    setActivePicker(null);
+  }, [initial, visible]);
+
+  function set(key: keyof typeof EMPTY_FORM, val: string) {
+    setForm((f) => ({ ...f, [key]: val }));
+  }
+
+  function handlePickerChange(event: DateTimePickerEvent, selected?: Date) {
+    if (!selected || event.type === "dismissed") {
+      setActivePicker(null);
+      return;
+    }
+    if (activePicker === "date") {
+      set("date", dateToStr(selected));
+    } else if (activePicker === "start_time") {
+      set("start_time", timeToStr(selected));
+    } else if (activePicker === "end_time") {
+      set("end_time", timeToStr(selected));
+    }
+    setActivePicker(null);
+  }
+
+  function pickerValue(): Date {
+    if (activePicker === "date") return form.date ? strToDate(form.date) : new Date();
+    if (activePicker === "start_time") return form.start_time ? strToTime(form.start_time) : strToTime("08:00");
+    if (activePicker === "end_time") return form.end_time ? strToTime(form.end_time) : strToTime("13:00");
+    return new Date();
+  }
+
+  function validate(): boolean {
+    if (!form.date) {
+      Alert.alert("Missing date", "Please select a date for the market day.");
+      return false;
+    }
+    if (!form.start_time) {
+      Alert.alert("Missing start time", "Please select a start time.");
+      return false;
+    }
+    if (!form.end_time) {
+      Alert.alert("Missing end time", "Please select an end time.");
+      return false;
+    }
+    if (!form.location.trim()) {
+      Alert.alert("Missing location", "Please enter a market location.");
+      return false;
+    }
+    return true;
+  }
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent>
+      <View style={modalStyles.overlay}>
+        <View style={modalStyles.sheet}>
+          <View style={modalStyles.handle} />
+
+          <Text style={styles.panelTitle}>
+            {initial?.date ? "Edit Market Day" : "New Market Day"}
+          </Text>
+
+          <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={{ gap: 12 }}>
+            <View style={styles.fieldGroup}>
+              <Text style={styles.label}>Date</Text>
+              <TouchableOpacity
+                style={[styles.input, { justifyContent: "center" }]}
+                onPress={() => setActivePicker(activePicker === "date" ? null : "date")}
+                activeOpacity={0.7}
+              >
+                <Text style={{ color: form.date ? "#182019" : "#B0BAB4", fontSize: 15 }}>
+                  {form.date ? formatDate(form.date) : "Select a date"}
+                </Text>
+              </TouchableOpacity>
+              {activePicker === "date" && (
+                <DateTimePicker
+                  value={pickerValue()}
+                  mode="date"
+                  display="spinner"
+                  minimumDate={new Date()}
+                  onChange={handlePickerChange}
+                  style={modalStyles.iosPicker}
+                />
+              )}
+            </View>
+
+            <View style={{ flexDirection: "row", gap: 12 }}>
+              <View style={[styles.fieldGroup, { flex: 1 }]}>
+                <Text style={styles.label}>Start time</Text>
+                <TouchableOpacity
+                  style={[styles.input, { justifyContent: "center" }]}
+                  onPress={() => setActivePicker(activePicker === "start_time" ? null : "start_time")}
+                  activeOpacity={0.7}
+                >
+                  <Text style={{ color: form.start_time ? "#182019" : "#B0BAB4", fontSize: 15 }}>
+                    {form.start_time ? formatTime(form.start_time) : "08:00"}
+                  </Text>
+                </TouchableOpacity>
+                {activePicker === "start_time" && (
+                  <DateTimePicker
+                    value={pickerValue()}
+                    mode="time"
+                    display="spinner"
+                    is24Hour
+                    onChange={handlePickerChange}
+                    style={modalStyles.iosPicker}
+                  />
+                )}
+              </View>
+
+              <View style={[styles.fieldGroup, { flex: 1 }]}>
+                <Text style={styles.label}>End time</Text>
+                <TouchableOpacity
+                  style={[styles.input, { justifyContent: "center" }]}
+                  onPress={() => setActivePicker(activePicker === "end_time" ? null : "end_time")}
+                  activeOpacity={0.7}
+                >
+                  <Text style={{ color: form.end_time ? "#182019" : "#B0BAB4", fontSize: 15 }}>
+                    {form.end_time ? formatTime(form.end_time) : "13:00"}
+                  </Text>
+                </TouchableOpacity>
+                {activePicker === "end_time" && (
+                  <DateTimePicker
+                    value={pickerValue()}
+                    mode="time"
+                    display="spinner"
+                    is24Hour
+                    onChange={handlePickerChange}
+                    style={modalStyles.iosPicker}
+                  />
+                )}
+              </View>
+            </View>
+
+            <View style={styles.fieldGroup}>
+              <Text style={styles.label}>Location</Text>
+              <TextInput
+                style={styles.input}
+                placeholder="e.g. Kristiansand Torv"
+                placeholderTextColor="#B0BAB4"
+                value={form.location}
+                onChangeText={(v) => set("location", v)}
+                autoCapitalize="words"
+              />
+            </View>
+
+            <View style={styles.fieldGroup}>
+              <Text style={styles.label}>Notes (optional)</Text>
+              <TextInput
+                style={[styles.input, styles.textArea]}
+                placeholder="Any reminders or details…"
+                placeholderTextColor="#B0BAB4"
+                value={form.notes}
+                onChangeText={(v) => set("notes", v)}
+                multiline
+                textAlignVertical="top"
+              />
+            </View>
+          </ScrollView>
+
+          <View style={[styles.bottomRow, { flexDirection: "row" }]}>
+            <TouchableOpacity
+              style={[styles.secondaryButton, { flex: 1 }]}
+              onPress={onClose}
+              activeOpacity={0.7}
+              disabled={saving}
+            >
+              <Text style={styles.secondaryButtonText}>Cancel</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.primaryButton, { flex: 1 }, saving && styles.buttonDisabled]}
+              onPress={() => validate() && onSave(form)}
+              activeOpacity={0.7}
+              disabled={saving}
+            >
+              {saving ? (
+                <ActivityIndicator color="#FFFFFF" />
+              ) : (
+                <Text style={styles.primaryButtonText}>Save</Text>
+              )}
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+export default function MarketDaysScreen() {
+  const { user } = useAuth();
+  const [marketDays, setMarketDays] = useState<MarketDay[]>([]);
+  const [filter, setFilter] = useState<Filter>("upcoming");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [modalVisible, setModalVisible] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [formInitial, setFormInitial] = useState<typeof EMPTY_FORM | null>(null);
+
+  const fetchMarketDays = useCallback(async () => {
+    if (!user || !supabase) return;
+    setLoading(true);
+    setError(null);
+    const { data, error } = await supabase
+      .from("market_days")
+      .select("*")
+      .eq("farmer_id", user.id)
+      .order("date", { ascending: true });
+
+    if (error) {
+      setError("Failed to load market days.");
+    } else {
+      const withStatus = (data ?? []).map((d) => ({
+        ...d,
+        status: deriveStatus(d.date),
+      }));
+      setMarketDays(withStatus);
+    }
+    setLoading(false);
+  }, [user]);
+
+  useEffect(() => {
+    fetchMarketDays();
+  }, [fetchMarketDays]);
+
+  const upcoming = marketDays.filter((d) => d.status !== "past");
+
+  const sorted = [...marketDays]
+    .filter((d) => {
+      if (filter === "upcoming") return d.status !== "past";
+      if (filter === "past") return d.status === "past";
+      return true;
+    })
+    .sort((a, b) =>
+      filter === "past"
+        ? b.date.localeCompare(a.date)
+        : a.date.localeCompare(b.date)
+    );
+
+  function openCreate() {
+    setEditingId(null);
+    setFormInitial(EMPTY_FORM);
+    setModalVisible(true);
+  }
+
+  function openEdit(item: MarketDay) {
+    setEditingId(item.id);
+    setFormInitial({
+      date: item.date,
+      start_time: item.start_time,
+      end_time: item.end_time,
+      location: item.location,
+      notes: item.notes ?? "",
+    });
+    setModalVisible(true);
+  }
+
+  async function handleSave(form: typeof EMPTY_FORM) {
+    if (!user || !supabase) return;
+    setSaving(true);
+
+    if (editingId) {
+      const { error } = await supabase
+        .from("market_days")
+        .update({
+          date: form.date,
+          start_time: form.start_time,
+          end_time: form.end_time,
+          location: form.location,
+          notes: form.notes,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", editingId);
+
+      if (error) {
+        Alert.alert("Error", "Failed to update market day.");
+      } else {
+        await fetchMarketDays();
+        setModalVisible(false);
+      }
+    } else {
+      const { error } = await supabase.from("market_days").insert({
+        farmer_id: user.id,
+        date: form.date,
+        start_time: form.start_time,
+        end_time: form.end_time,
+        location: form.location,
+        notes: form.notes,
+      });
+
+      if (error) {
+        Alert.alert("Error", "Failed to create market day.");
+      } else {
+        await fetchMarketDays();
+        setModalVisible(false);
+      }
+    }
+
+    setSaving(false);
+  }
+
+  function handleDelete(id: string) {
+    Alert.alert(
+      "Cancel market day",
+      "Are you sure you want to remove this market day?",
+      [
+        { text: "Keep", style: "cancel" },
+        {
+          text: "Remove",
+          style: "destructive",
+          onPress: async () => {
+            if (!supabase) return;
+            const { error } = await supabase
+              .from("market_days")
+              .delete()
+              .eq("id", id);
+            if (error) {
+              Alert.alert("Error", "Failed to remove market day.");
+            } else {
+              await fetchMarketDays();
+            }
+          },
+        },
+      ]
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.page}>
+      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+        <View style={styles.heroCard}>
+          <View style={styles.heroCopy}>
+            <Text style={styles.eyebrow}>Farmer Dashboard</Text>
+            <Text style={styles.heroTitle}>Market Days</Text>
+            <Text style={styles.heroBody}>
+              Schedule and manage your market appearances. Customers can see where to find you.
+            </Text>
+          </View>
+          {upcoming.length > 0 && (
+            <View style={styles.readonlyItem}>
+              <Text style={styles.readonlyLabel}>Scheduled</Text>
+              <Text style={styles.readonlyValue}>
+                {upcoming.length} {upcoming.length === 1 ? "market day" : "market days"}
+              </Text>
+            </View>
+          )}
+          <View style={styles.dashboardButtonRow}>
+            <TouchableOpacity style={styles.dashboardButton} onPress={openCreate} activeOpacity={0.8}>
+              <Text style={styles.dashboardButtonText}>+ Add Market Day</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+
+        <View style={styles.panel}>
+          <View style={{ flexDirection: "row", gap: 8 }}>
+            {(["upcoming", "past", "all"] as Filter[]).map((f) => (
+              <TouchableOpacity
+                key={f}
+                style={[styles.inlineButton, filter === f && styles.optionCardActive]}
+                onPress={() => setFilter(f)}
+                activeOpacity={0.7}
+              >
+                <Text style={[styles.inlineButtonText, filter === f && styles.optionTitleActive]}>
+                  {f.charAt(0).toUpperCase() + f.slice(1)}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </View>
+
+        {loading ? (
+          <View style={styles.loadingPanel}>
+            <ActivityIndicator color="#2F6A3E" />
+            <Text style={styles.panelBody}>Loading market days…</Text>
+          </View>
+        ) : error ? (
+          <View style={styles.panel}>
+            <Text style={styles.errorText}>{error}</Text>
+            <TouchableOpacity style={styles.inlineButton} onPress={fetchMarketDays}>
+              <Text style={styles.inlineButtonText}>Try again</Text>
+            </TouchableOpacity>
+          </View>
+        ) : sorted.length === 0 ? (
+          <View style={styles.panel}>
+            <Text style={styles.panelTitle}>
+              {filter === "past" ? "No past market days" : "Nothing scheduled"}
+            </Text>
+            <Text style={styles.panelBody}>
+              {filter === "past"
+                ? "Your completed market days will appear here."
+                : `Tap "+ Add Market Day" to schedule your first appearance.`}
+            </Text>
+          </View>
+        ) : (
+          sorted.map((item) => (
+            <MarketDayCard key={item.id} item={item} onEdit={openEdit} onDelete={handleDelete} />
+          ))
+        )}
+      </ScrollView>
+
+      <MarketDayModal
+        visible={modalVisible}
+        initial={formInitial}
+        onSave={handleSave}
+        onClose={() => setModalVisible(false)}
+        saving={saving}
+      />
+    </SafeAreaView>
+  );
+}
+
+const shadow = {
+  boxShadow: "0px 18px 40px rgba(26, 41, 30, 0.08)",
+} as const;
+
+const modalStyles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: "rgba(24,32,25,0.35)",
+    justifyContent: "flex-end",
+  },
+  sheet: {
+    backgroundColor: "#FFFFFF",
+    borderTopLeftRadius: 28,
+    borderTopRightRadius: 28,
+    padding: 24,
+    paddingBottom: Platform.OS === "ios" ? 40 : 24,
+    gap: 16,
+    maxHeight: "90%",
+  },
+  handle: {
+    width: 40,
+    height: 4,
+    backgroundColor: "#D8DDD8",
+    borderRadius: 2,
+    alignSelf: "center",
+    marginBottom: 4,
+  },
+  iosPicker: {
+    width: "100%",
+    backgroundColor: "#F7FBF5",
+    borderRadius: 12,
+    marginTop: 4,
+  },
+});
+
+const styles = StyleSheet.create({
+  page: {
+    flex: 1,
+    backgroundColor: "#F4F5EF",
+  },
+  scrollContent: {
+    gap: 16,
+    paddingHorizontal: 18,
+    paddingVertical: 24,
+  },
+  heroCard: {
+    backgroundColor: "#21432D",
+    borderRadius: 28,
+    gap: 16,
+    padding: 22,
+    ...shadow,
+  },
+  avatarCircle: {
+    alignItems: "center",
+    backgroundColor: "#F3E6BB",
+    borderRadius: 999,
+    height: 64,
+    justifyContent: "center",
+    width: 64,
+  },
+  avatarText: {
+    color: "#21432D",
+    fontSize: 22,
+    fontWeight: "800",
+  },
+  heroCopy: {
+    gap: 6,
+  },
+  eyebrow: {
+    color: "#B9D1BF",
+    fontSize: 12,
+    fontWeight: "700",
+    letterSpacing: 0.4,
+    textTransform: "uppercase",
+  },
+  heroTitle: {
+    color: "#FFFFFF",
+    fontSize: 28,
+    fontWeight: "800",
+    letterSpacing: -0.7,
+  },
+  heroBody: {
+    color: "#D8E2DB",
+    fontSize: 15,
+    lineHeight: 22,
+  },
+  panel: {
+    backgroundColor: "#FFFFFF",
+    borderColor: "#DFE4DB",
+    borderRadius: 24,
+    borderWidth: 1,
+    gap: 14,
+    padding: 18,
+    ...shadow,
+  },
+  loadingPanel: {
+    alignItems: "center",
+    backgroundColor: "#FFFFFF",
+    borderColor: "#DFE4DB",
+    borderRadius: 24,
+    borderWidth: 1,
+    flexDirection: "row",
+    gap: 10,
+    padding: 18,
+    ...shadow,
+  },
+  panelTitle: {
+    color: "#182019",
+    fontSize: 18,
+    fontWeight: "800",
+  },
+  panelBody: {
+    color: "#5D6A60",
+    fontSize: 14,
+    lineHeight: 21,
+  },
+  dashboardButtonRow: {
+    marginTop: 15,
+  },
+  dashboardButton: {
+    alignItems: "center",
+    backgroundColor: "#2F6A3E",
+    borderRadius: 18,
+    justifyContent: "center",
+    minHeight: 48,
+    paddingHorizontal: 18,
+  },
+  dashboardButtonText: {
+    color: "#FFFFFF",
+    fontSize: 15,
+    fontWeight: "700",
+  },
+  sectionHeader: {
+    gap: 12,
+  },
+  sectionCopy: {
+    gap: 4,
+  },
+  readonlyGrid: {
+    gap: 12,
+  },
+  readonlyItem: {
+    backgroundColor: "#F7FBF5",
+    borderColor: "#D7E2D3",
+    borderRadius: 18,
+    borderWidth: 1,
+    gap: 4,
+    padding: 14,
+  },
+  readonlyLabel: {
+    color: "#5D6A60",
+    fontSize: 12,
+    fontWeight: "700",
+    letterSpacing: 0.3,
+    textTransform: "uppercase",
+  },
+  readonlyValue: {
+    color: "#182019",
+    fontSize: 16,
+    fontWeight: "700",
+    lineHeight: 22,
+  },
+  readonlyMeta: {
+    color: "#445148",
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  textBlock: {
+    gap: 6,
+  },
+  longValue: {
+    color: "#213025",
+    fontSize: 15,
+    lineHeight: 22,
+  },
+  inlineButton: {
+    alignSelf: "flex-start",
+    backgroundColor: "#EEF5EB",
+    borderRadius: 999,
+    paddingHorizontal: 14,
+    paddingVertical: 9,
+  },
+  inlineButtonText: {
+    color: "#214C2D",
+    fontSize: 13,
+    fontWeight: "700",
+  },
+  formGrid: {
+    gap: 12,
+  },
+  fieldGroup: {
+    gap: 8,
+  },
+  label: {
+    color: "#182019",
+    fontSize: 14,
+    fontWeight: "700",
+  },
+  input: {
+    backgroundColor: "#FFFFFF",
+    borderColor: "#DDE4D9",
+    borderRadius: 18,
+    borderWidth: 1,
+    color: "#182019",
+    fontSize: 15,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+  },
+  textArea: {
+    minHeight: 110,
+  },
+  optionGrid: {
+    gap: 12,
+  },
+  optionCard: {
+    backgroundColor: "#FFFFFF",
+    borderColor: "#DDE4D9",
+    borderRadius: 20,
+    borderWidth: 1,
+    gap: 6,
+    padding: 16,
+  },
+  optionCardActive: {
+    backgroundColor: "#EEF5EB",
+    borderColor: "#2F6A3E",
+  },
+  optionTitle: {
+    color: "#182019",
+    fontSize: 15,
+    fontWeight: "700",
+  },
+  optionTitleActive: {
+    color: "#214C2D",
+  },
+  optionBody: {
+    color: "#5D6A60",
+    fontSize: 13,
+    lineHeight: 20,
+  },
+  optionBodyActive: {
+    color: "#3A5441",
+  },
+  actionRow: {
+    gap: 10,
+    marginTop: 4,
+  },
+  bottomRow: {
+    gap: 12,
+    marginBottom: 8,
+  },
+  primaryButton: {
+    alignItems: "center",
+    backgroundColor: "#2F6A3E",
+    borderRadius: 18,
+    justifyContent: "center",
+    minHeight: 52,
+    paddingHorizontal: 18,
+  },
+  primaryButtonText: {
+    color: "#FFFFFF",
+    fontSize: 15,
+    fontWeight: "700",
+  },
+  secondaryButton: {
+    alignItems: "center",
+    borderColor: "#BFD2B9",
+    borderRadius: 18,
+    borderWidth: 1,
+    justifyContent: "center",
+    minHeight: 52,
+    paddingHorizontal: 18,
+  },
+  secondaryButtonText: {
+    color: "#2F6A3E",
+    fontSize: 15,
+    fontWeight: "700",
+  },
+  signOutButton: {
+    backgroundColor: "#314A37",
+  },
+  buttonDisabled: {
+    opacity: 0.7,
+  },
+  errorText: {
+    color: "#9C5B4D",
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  successText: {
+    color: "#2E5B3C",
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  footerText: {
+    color: "#5D6A60",
+    fontSize: 14,
+    lineHeight: 22,
+  },
+  footerLink: {
+    color: "#2F6A3E",
+    fontWeight: "700",
+  },
+});


### PR DESCRIPTION
Closes #36, partially completes #37

**What's in this PR**

Signed in farmers now have their own dashboard which can be accessed through their profile, in which they are able to see the manage market days button as well. Farmers can create market days, edit them and delete them. They can also see all of their upcoming market days aswell as their previous ones. 

**Dashboard Screen `(/farmer_dashboard/index)` **

- Hero card for farmer users with dashboard messaging
- Go to Market Management button which redirects to `(/farmer_dashboard/market)`

**Market Day Screen `(/farmer_dashboard/market)`**

- Fetches the farmers market days from Supabase with their corresponding id
- Market days shows status Upcoming/Today/Past
- Shows amount of scheduled market days
- Added CRUD functionality for market days
- 

**Styling**

- Kept current file-local styled components
<img width="384" height="890" alt="image_2026-04-14_021815250" src="https://github.com/user-attachments/assets/ef4a873a-b1f9-4998-9631-714478f095ae" />
<img width="383" height="886" alt="image_2026-04-14_021831645" src="https://github.com/user-attachments/assets/e8266b02-b0e0-4f3b-8ff9-527cfea58ad2" />
<img width="386" height="888" alt="image_2026-04-14_021846464" src="https://github.com/user-attachments/assets/5077932c-69cf-4608-8a26-ab653706618e" />
<img width="385" height="889" alt="image" src="https://github.com/user-attachments/assets/0f0d8d84-2711-4a3a-adb6-3630bf24139b" />
