### PR TITLE
Users needs to be able to browse farms

### DIFF
--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -8,6 +8,7 @@ import {
   useWindowDimensions,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { FarmList } from "../components/FarmList";
 import { useFarmProfile } from "../hooks/useFarmProfile";
 import { isSupabaseConfigured, supabaseConfigError } from "../lib/supabase";
 import { useAuth } from "../providers/auth-provider";
@@ -102,7 +103,7 @@ const saturdayMarkets = [
 
 export default function Index() {
   const { width } = useWindowDimensions();
-  const { session, user } = useAuth();
+  const { session, user, profile } = useAuth();
   const { farmProfile } = useFarmProfile(user?.id);
   const isWide = width >= 940;
   const isMedium = width >= 720;
@@ -316,16 +317,18 @@ export default function Index() {
                     >
                       Open account
                     </Link>
-                    <Link
-                      href={
-                        farmProfile
-                          ? (`/farm/${farmProfile.id}` as Href)
-                          : ("/farm/edit" as Href)
-                      }
-                      style={[styles.ctaLink, styles.ctaLinkPrimary]}
-                    >
-                      {farmProfile ? "Farm management" : "Create a farm"}
-                    </Link>
+                    {profile?.role === "farmer" ? (
+                      <Link
+                        href={
+                          farmProfile
+                            ? (`/farm/${farmProfile.id}` as Href)
+                            : ("/farm/edit" as Href)
+                        }
+                        style={[styles.ctaLink, styles.ctaLinkPrimary]}
+                      >
+                        {farmProfile ? "Farm management" : "Create a farm"}
+                      </Link>
+                    ) : null}
                   </>
                 ) : (
                   <>
@@ -342,6 +345,8 @@ export default function Index() {
                 )}
               </View>
             </View>
+
+            <FarmList />
 
             <View style={styles.authStatusCard}>
               <Text style={styles.bootstrapEyebrow}>Payments</Text>

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -9,7 +9,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { FarmList } from "../components/FarmList";
-import { useFarmProfile } from "../hooks/useFarmProfile";
+import { useAllFarmProfiles, useFarmProfile } from "../hooks/useFarmProfile";
 import { isSupabaseConfigured, supabaseConfigError } from "../lib/supabase";
 import { useAuth } from "../providers/auth-provider";
 
@@ -105,6 +105,7 @@ export default function Index() {
   const { width } = useWindowDimensions();
   const { session, user, profile } = useAuth();
   const { farmProfile } = useFarmProfile(user?.id);
+  const { farms, loading: farmsLoading } = useAllFarmProfiles();
   const isWide = width >= 940;
   const isMedium = width >= 720;
   const phoneWidth = width < 390 ? 250 : 286;
@@ -346,7 +347,7 @@ export default function Index() {
               </View>
             </View>
 
-            <FarmList />
+            <FarmList farms={farms} loading={farmsLoading} />
 
             <View style={styles.authStatusCard}>
               <Text style={styles.bootstrapEyebrow}>Payments</Text>

--- a/src/components/FarmList.tsx
+++ b/src/components/FarmList.tsx
@@ -1,4 +1,4 @@
-import { type Href, useRouter } from "expo-router";
+import { Link, type Href } from "expo-router";
 import { useState } from "react";
 import {
   ActivityIndicator,
@@ -7,13 +7,15 @@ import {
   TextInput,
   View,
 } from "react-native";
-
-import { useAllFarmProfiles } from "../hooks/useFarmProfile";
+import { type FarmProfile } from "../lib/farmProfiles";
 import { farmStyles } from "../styles/farm-styles";
 
-export function FarmList() {
-  const router = useRouter();
-  const { farms, loading } = useAllFarmProfiles();
+type Props = {
+  farms: FarmProfile[];
+  loading: boolean;
+};
+
+export function FarmList({ farms, loading }: Props) {
   const [query, setQuery] = useState("");
 
   const filtered = query.trim()
@@ -41,17 +43,16 @@ export function FarmList() {
         <Text style={farmStyles.emptyText}>No farms found.</Text>
       ) : (
         filtered.map((farm) => (
-          <Pressable
-            key={farm.id}
-            accessibilityRole="button"
-            onPress={() => router.push(`/farm/${farm.id}` as Href)}
-            style={farmStyles.readonlyItem}
-          >
-            <Text style={farmStyles.rowName}>{farm.farm_name}</Text>
-            {farm.farm_location ? (
-              <Text style={farmStyles.readonlyMeta}>{farm.farm_location}</Text>
-            ) : null}
-          </Pressable>
+          <Link key={farm.id} href={`/farm/${farm.id}` as Href} asChild>
+            <Pressable style={farmStyles.readonlyItem}>
+              <Text style={farmStyles.rowName}>{farm.farm_name}</Text>
+              {farm.farm_location ? (
+                <Text style={farmStyles.readonlyMeta}>
+                  {farm.farm_location}
+                </Text>
+              ) : null}
+            </Pressable>
+          </Link>
         ))
       )}
     </View>

--- a/src/components/FarmList.tsx
+++ b/src/components/FarmList.tsx
@@ -1,0 +1,59 @@
+import { type Href, useRouter } from "expo-router";
+import { useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+
+import { useAllFarmProfiles } from "../hooks/useFarmProfile";
+import { farmStyles } from "../styles/farm-styles";
+
+export function FarmList() {
+  const router = useRouter();
+  const { farms, loading } = useAllFarmProfiles();
+  const [query, setQuery] = useState("");
+
+  const filtered = query.trim()
+    ? farms.filter(
+        (f) =>
+          f.farm_name.toLowerCase().includes(query.toLowerCase()) ||
+          (f.farm_location ?? "").toLowerCase().includes(query.toLowerCase()),
+      )
+    : farms;
+
+  return (
+    <View style={farmStyles.panel}>
+      <Text style={farmStyles.listEyebrow}>Farms</Text>
+      <Text style={farmStyles.panelTitle}>Browse registered farms</Text>
+      <TextInput
+        onChangeText={setQuery}
+        placeholder="Search by name or location"
+        placeholderTextColor="#7A867D"
+        style={farmStyles.searchInput}
+        value={query}
+      />
+      {loading ? (
+        <ActivityIndicator color="#2F6A3E" />
+      ) : filtered.length === 0 ? (
+        <Text style={farmStyles.emptyText}>No farms found.</Text>
+      ) : (
+        filtered.map((farm) => (
+          <Pressable
+            key={farm.id}
+            accessibilityRole="button"
+            onPress={() => router.push(`/farm/${farm.id}` as Href)}
+            style={farmStyles.readonlyItem}
+          >
+            <Text style={farmStyles.rowName}>{farm.farm_name}</Text>
+            {farm.farm_location ? (
+              <Text style={farmStyles.readonlyMeta}>{farm.farm_location}</Text>
+            ) : null}
+          </Pressable>
+        ))
+      )}
+    </View>
+  );
+}

--- a/src/hooks/useFarmProfile.ts
+++ b/src/hooks/useFarmProfile.ts
@@ -14,12 +14,12 @@
  *   <Text>{farmProfile.farm_name}</Text>
  */
 import { useEffect, useState } from "react";
-
 import {
   type FarmProfile,
   fetchAllFarmProfiles,
   fetchFarmProfileByUserId,
 } from "../lib/farmProfiles";
+import { isSupabaseConfigured } from "../lib/supabase";
 
 export function useFarmProfile(userId: string | undefined): {
   farmProfile: FarmProfile | null;
@@ -48,6 +48,7 @@ export function useAllFarmProfiles(): {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    if (!isSupabaseConfigured) return setLoading(false);
     fetchAllFarmProfiles()
       .then(setFarms)
       .catch(() => setFarms([]))

--- a/src/hooks/useFarmProfile.ts
+++ b/src/hooks/useFarmProfile.ts
@@ -17,6 +17,7 @@ import { useEffect, useState } from "react";
 
 import {
   type FarmProfile,
+  fetchAllFarmProfiles,
   fetchFarmProfileByUserId,
 } from "../lib/farmProfiles";
 
@@ -37,4 +38,21 @@ export function useFarmProfile(userId: string | undefined): {
   }, [userId]);
 
   return { farmProfile, loading };
+}
+
+export function useAllFarmProfiles(): {
+  farms: FarmProfile[];
+  loading: boolean;
+} {
+  const [farms, setFarms] = useState<FarmProfile[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchAllFarmProfiles()
+      .then(setFarms)
+      .catch(() => setFarms([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return { farms, loading };
 }

--- a/src/lib/farmProfiles.ts
+++ b/src/lib/farmProfiles.ts
@@ -69,6 +69,18 @@ export async function upsertFarmProfile(
   return data;
 }
 
+export async function fetchAllFarmProfiles(): Promise<FarmProfile[]> {
+  if (!supabase) throw new Error("Supabase is not configured.");
+
+  const { data, error } = await supabase
+    .from("farm_profiles")
+    .select("*")
+    .order("farm_name", { ascending: true });
+
+  if (error) throw error;
+  return data ?? [];
+}
+
 export async function deleteFarmProfile(userId: string): Promise<void> {
   if (!supabase) throw new Error("Supabase is not configured.");
 

--- a/src/styles/farm-styles.tsx
+++ b/src/styles/farm-styles.tsx
@@ -183,4 +183,30 @@ export const farmStyles = StyleSheet.create({
     fontSize: 14,
     padding: 18,
   },
+  listEyebrow: {
+    color: "#2F6A3E",
+    fontSize: 11,
+    fontWeight: "800",
+    letterSpacing: 1,
+    textTransform: "uppercase",
+  },
+  searchInput: {
+    backgroundColor: "#F7FBF5",
+    borderColor: "#D7E2D3",
+    borderRadius: 18,
+    borderWidth: 1,
+    color: "#182019",
+    fontSize: 15,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  emptyText: {
+    color: "#5D6A60",
+    fontSize: 14,
+  },
+  rowName: {
+    color: "#182019",
+    fontSize: 15,
+    fontWeight: "700",
+  },
 });


### PR DESCRIPTION
## Users can browse farms

Closes #62
Follows #60

### What's in this PR

Users can now view a list of registered farms on the home screen, search by name or location, and tap a farm to view its details.

The "Create Farm" button is now restricted to farmer accounts only, regular users no longer see it, as farm management is a farmer-specific feature.

### Changes

- `fetchAllFarmProfiles` added to fetch all farm profiles ordered by name
- `useAllFarmProfiles` hook added to `useFarmProfile.ts`
- `FarmList` component, presentational, accepts `farms` and `loading` as props, search filtered client-side, navigation via `Link`
- Farm list rendered in `index.tsx` below the account section
- Farm management link gated behind `profile.role === "farmer"`

### Screenshots

<img width="410" height="942" alt="1" src="https://github.com/user-attachments/assets/c684e412-48d9-43b7-9d06-01de77700678" />