### PR TITLE
feat: reinforce role-based access control and route guards

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -6,6 +6,8 @@ import { StripeProvider } from "@stripe/stripe-react-native";
 import { AuthProvider, useAuth } from "../providers/auth-provider";
 import { CartProvider, useCart } from "../providers/cart-provider";
 
+const AUTH_ROUTES = ["/auth/login", "/auth/register", "/auth/confirm"];
+
 function RootNavigator() {
   const { isLoading, session } = useAuth();
   const { clearCart } = useCart();
@@ -17,25 +19,20 @@ function RootNavigator() {
   }, [session, clearCart]);
 
   useEffect(() => {
-    if (isLoading) {
-      return;
-    }
+    if (isLoading) return;
 
-    if (pathname === "/") {
-      router.replace("/(tabs)" as Href);
-      return;
-    }
-
-    if (!session && pathname === "/account") {
+    if (!session && !AUTH_ROUTES.includes(pathname)) {
       router.replace("/auth/login" as Href);
       return;
     }
 
-    if (
-      session &&
-      (pathname === "/auth/login" || pathname === "/auth/register")
-    ) {
+    if (session && AUTH_ROUTES.includes(pathname)) {
       router.replace("/account" as Href);
+      return;
+    }
+
+    if (session && pathname === "/") {
+      router.replace("/(tabs)" as Href);
     }
   }, [isLoading, pathname, router, session]);
 

--- a/src/app/farm/edit.tsx
+++ b/src/app/farm/edit.tsx
@@ -1,7 +1,7 @@
 import { geocodeAddress } from "@/lib/location/locationService";
 import { AddressInput } from "@/lib/location/types";
 import * as Location from "expo-location";
-import { useRouter } from "expo-router";
+import { useRouter, type Href } from "expo-router";
 import { useEffect, useState } from "react";
 import {
   ActivityIndicator,
@@ -20,7 +20,7 @@ import { useAuth } from "../../providers/auth-provider";
 import { farmStyles } from "../../styles/farm-styles";
 
 export default function FarmEditScreen() {
-  const { user, profile } = useAuth();
+  const { user, profile, profileLoading } = useAuth();
   const router = useRouter();
 
   const [farmName, setFarmName] = useState(""); // State for farm name
@@ -39,6 +39,13 @@ export default function FarmEditScreen() {
   });
   const [, setLatitude] = useState<number | null>(null); // Set state for latitude
   const [, setLongitude] = useState<number | null>(null); // Set state for longitude
+
+  useEffect(() => {
+    if (profileLoading) return;
+    if (profile?.role !== "farmer") {
+      router.replace("/(tabs)" as Href);
+    }
+  }, [profile, profileLoading, router]);
 
   // Fetch existing farm profile
   useEffect(() => {
@@ -117,24 +124,16 @@ export default function FarmEditScreen() {
     }
   };
 
-  // Only allow farmers to access this screen
-  if (profile?.role !== "farmer") {
-    return (
-      <SafeAreaView style={farmStyles.page}>
-        <Text style={farmStyles.errorText}>
-          Only farmers can edit a farm profile.
-        </Text>
-      </SafeAreaView>
-    );
-  }
-
-  // Show loading state while fetching existing profile
-  if (loading) {
+  if (profileLoading || loading) {
     return (
       <SafeAreaView style={farmStyles.page}>
         <ActivityIndicator color="#2F6A3E" />
       </SafeAreaView>
     );
+  }
+
+  if (profile?.role !== "farmer") {
+    return null;
   }
 
   return (

--- a/src/app/farmer_dashboard/_layout.tsx
+++ b/src/app/farmer_dashboard/_layout.tsx
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+import { ActivityIndicator, StyleSheet, View } from "react-native";
+import { Slot, useRouter, type Href } from "expo-router";
+
+import { useAuth } from "../../providers/auth-provider";
+
+export default function FarmerDashboardLayout() {
+  const { profile, profileLoading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (profileLoading) return;
+    if (profile?.role !== "farmer") {
+      router.replace("/(tabs)" as Href);
+    }
+  }, [profile, profileLoading, router]);
+
+  if (profileLoading) {
+    return (
+      <View style={styles.loadingScreen}>
+        <ActivityIndicator color="#2F6A3E" size="large" />
+      </View>
+    );
+  }
+
+  if (profile?.role !== "farmer") {
+    return null;
+  }
+
+  return <Slot />;
+}
+
+const styles = StyleSheet.create({
+  loadingScreen: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#F6F7F3",
+  },
+});


### PR DESCRIPTION
Closes #71 

## Summary
- All unauthenticated users are now redirected to `/auth/login` regardless of which route they land on — previously only `/account` was protected
- Added `farmer_dashboard/_layout.tsx` as a structural guard that blocks customers from the entire farmer dashboard route group
- Replaced the soft error message in `/farm/edit` with an immediate redirect for non-farmers

## Why a layout file for `farmer_dashboard/`
Expo Router's file-based routing means a `_layout.tsx` inside a folder automatically wraps every screen in that group. This gives structural enforcement, any screen added under `farmer_dashboard/` in the future is protected without any extra work. Per-screen checks would require repeating the redirect in every file and are easy to forget.

## Bug fixed
Tapping the Account tab while unauthenticated previously crashed the app. The tab lives at `/(tabs)/account`, which the old guard (`pathname === "/account"`) never matched. The new blanket redirect covers all non-auth routes, including the tab navigator.
