### PR TITLE
fix: [BUG]: White Background Map Section #75

### DIFF
--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -1,6 +1,6 @@
+import { useCart } from "@/providers/cart-provider";
 import { Ionicons } from "@expo/vector-icons";
 import { Tabs } from "expo-router";
-import { useCart } from "@/providers/cart-provider";
 
 export default function TabsLayout() {
   const { totalItems } = useCart();
@@ -49,6 +49,22 @@ export default function TabsLayout() {
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="map-outline" size={size} color={color} />
           ),
+          tabBarStyle: {
+            position: "absolute",
+            backgroundColor: "#C2DDB9",
+            borderTopWidth: 0,
+            borderRadius: 24,
+            marginHorizontal: 16,
+            marginBottom: 20,
+            elevation: 4,
+            shadowOpacity: 0.04,
+            shadowRadius: 4,
+            shadowColor: "#000",
+            shadowOffset: { width: 0, height: -1 },
+            height: 64,
+            paddingBottom: 10,
+            paddingTop: 8,
+          },
         }}
       />
       <Tabs.Screen

--- a/src/app/map.tsx
+++ b/src/app/map.tsx
@@ -6,23 +6,22 @@ import MapView, { Marker, PROVIDER_GOOGLE } from "react-native-maps";
 export default function MapScreen() {
   const router = useRouter();
 
-  // Loading farms with a hook for farm-profiles.
   const { farms } = useAllFarmProfiles();
 
-  // Filtering out farms without coordinates
   const farmsWithCoordinates = farms.filter(
     (farm) => farm.latitude !== null && farm.longitude !== null,
   );
+
   return (
     <View style={styles.container}>
       <MapView
         provider={PROVIDER_GOOGLE}
         style={styles.map}
-        // Setting the start possision for the map, and zoom level. Approximatly Kristiansand / Grimstad
+        // Setting the start position for the map, and zoom level. Approximately Kristiansand / Grimstad
         initialRegion={{
           latitude: 58.1467,
           longitude: 7.9956,
-          // Zoom leval
+          // Zoom level
           latitudeDelta: 0.5,
           longitudeDelta: 0.5,
         }}
@@ -48,6 +47,10 @@ export default function MapScreen() {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1 },
-  map: { flex: 1 },
+  container: {
+    flex: 1,
+  },
+  map: {
+    ...StyleSheet.absoluteFillObject,
+  },
 });


### PR DESCRIPTION
The Google Maps screen displayed a white background behind the tab navigator, breaking the immersive feel of the map view.
Closes issue #75

## Changes
- Set `position: absolute` on tab bar style for map screen in `(tabs)/_layout.tsx`
- Set `StyleSheet.absoluteFillObject` on map style in `map.tsx` so the map fills the entire screen" --base main


<img width="495" height="1106" alt="Screenshot 2026-04-28 142901" src="https://github.com/user-attachments/assets/a705228c-8a4d-4e10-8695-d4c16db13407" />
