### PR TITLE
chore: add Android SDK setup

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -36,14 +36,30 @@
 
 A local build is required because the app uses native libraries that are not supported in Expo Go or Web.
 
-1. Make sure you have Android Studio installed with an emulator set up, or a physical Android device connected.
+1. Make sure you have Android Studio installed with an emulator set up, or a physical Android device connected. In Android Studio's SDK Manager, install:
+   - Android SDK Platform 36
+   - Android SDK Build-Tools 36.0.0
+   - NDK (Side by side) 27.1.12297006
+   - Android SDK Command-line Tools
 
 2. Make sure `OpenJDK 17` is installed.
 
-3. Run the following command to build and launch the app:
+3. Set up the local Android SDK path:
 
 ```bash
-   npx expo run:android
+   npm run setup:android
+```
+
+This writes `android/local.properties`, which is intentionally ignored by git because the SDK path is different on each developer machine. If your SDK is installed somewhere non-standard, pass the path explicitly:
+
+```bash
+   npm run setup:android -- /path/to/android/sdk
+```
+
+4. Run the following command to build and launch the app:
+
+```bash
+   npm run android
 ```
 
 This compiles the native code and installs the app directly on your device or emulator.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",
+    "setup:android": "node ./scripts/setupAndroidSdk.js",
+    "preandroid": "npm run setup:android",
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",

--- a/scripts/setupAndroidSdk.js
+++ b/scripts/setupAndroidSdk.js
@@ -1,0 +1,73 @@
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const rootDir = path.resolve(__dirname, "..");
+const androidDir = path.join(rootDir, "android");
+const localPropertiesPath = path.join(androidDir, "local.properties");
+
+function normalizeSdkPath(sdkPath) {
+  const normalized = path.resolve(sdkPath).replace(/\\/g, "/");
+  return normalized.replace(/^([A-Za-z]):/, "$1\\:");
+}
+
+function candidatePaths() {
+  const candidates = [
+    process.argv[2],
+    process.env.ANDROID_HOME,
+    process.env.ANDROID_SDK_ROOT,
+  ];
+
+  if (process.env.LOCALAPPDATA) {
+    candidates.push(path.join(process.env.LOCALAPPDATA, "Android", "Sdk"));
+  }
+
+  const homeDir = os.homedir();
+  candidates.push(
+    path.join(homeDir, "Library", "Android", "sdk"),
+    path.join(homeDir, "Android", "Sdk"),
+  );
+
+  return candidates.filter(Boolean);
+}
+
+function findSdkPath() {
+  return candidatePaths().find((candidate) => fs.existsSync(candidate));
+}
+
+function upsertSdkDir(content, sdkPath) {
+  const sdkDirLine = `sdk.dir=${normalizeSdkPath(sdkPath)}`;
+
+  if (!content.trim()) {
+    return `${sdkDirLine}\n`;
+  }
+
+  if (/^sdk\.dir=.*$/m.test(content)) {
+    return content.replace(/^sdk\.dir=.*$/m, sdkDirLine);
+  }
+
+  const separator = content.endsWith("\n") ? "" : "\n";
+  return `${content}${separator}${sdkDirLine}\n`;
+}
+
+const sdkPath = findSdkPath();
+
+if (!sdkPath) {
+  console.error("Android SDK not found.");
+  console.error("Install Android Studio, then either:");
+  console.error("- set ANDROID_HOME or ANDROID_SDK_ROOT, or");
+  console.error("- run: npm run setup:android -- <path-to-android-sdk>");
+  process.exit(1);
+}
+
+if (!fs.existsSync(androidDir)) {
+  console.error(`Android directory not found: ${androidDir}`);
+  process.exit(1);
+}
+
+const currentContent = fs.existsSync(localPropertiesPath)
+  ? fs.readFileSync(localPropertiesPath, "utf8")
+  : "";
+
+fs.writeFileSync(localPropertiesPath, upsertSdkDir(currentContent, sdkPath));
+console.log(`Updated android/local.properties with SDK path: ${sdkPath}`);

--- a/scripts/setupAndroidSdk.js
+++ b/scripts/setupAndroidSdk.js
@@ -70,4 +70,4 @@ const currentContent = fs.existsSync(localPropertiesPath)
   : "";
 
 fs.writeFileSync(localPropertiesPath, upsertSdkDir(currentContent, sdkPath));
-console.log(`Updated android/local.properties with SDK path: ${sdkPath}`);
+console.info(`Updated android/local.properties with SDK path: ${sdkPath}`);


### PR DESCRIPTION
This adds a small helper script for Android local development setup.

The script lives in `scripts/setupAndroidSdk.js`. It finds the local Android SDK path from `ANDROID_HOME`, `ANDROID_SDK_ROOT`, or the common default install locations, then writes it to `android/local.properties`.

That file is intentionally ignored by git because every developer's SDK path is different.

## Why

`npx expo run:android` fails if Gradle cannot find the Android SDK. This gives each developer a quick way to generate the right local config instead of manually creating `android/local.properties`.

## How to use it

Run:

```bash
npm run setup:android
```

If the SDK is installed somewhere custom:

```bash
npm run setup:android -- /path/to/android/sdk
```

`npm run android` also runs the setup step automatically before starting the Expo Android build.

## Also updated

`CONTRIBUTE.md` now documents the Android SDK/NDK pieces needed for local builds, including NDK `27.1.12297006`.