### PR TITLE
fix: remove product data prints

### DIFF
--- a/scripts/generateProductData.ts
+++ b/scripts/generateProductData.ts
@@ -204,18 +204,6 @@ async function generateProductData(): Promise<void> {
 
   const outputPath = path.resolve(process.cwd(), "src/data/produceData.json");
   await writeFile(outputPath, JSON.stringify(output, null, 2), "utf-8");
-
-  process.stdout.write(`Saved produce data to ${outputPath}\n`);
-  process.stdout.write(
-    `Matched ${output.totalMatched} out of ${output.totalRequested} produce items.\n`,
-  );
-
-  if (unmatched.length > 0) {
-    process.stdout.write("Unmatched products:\n");
-    for (const name of unmatched) {
-      process.stdout.write(`- ${name}\n`);
-    }
-  }
 }
 
 generateProductData().catch((error) => {


### PR DESCRIPTION
## Summary
- remove the leftover `process.stdout.write()` progress output from the product data generator
- keep failure output in place for script errors

Closes #78.

## Checks
- `npm run format:check`
- `npm run typecheck`
- `EXPO_NO_TELEMETRY=1 npm run lint`
- `rg -n "console\.log\s*\(|process\.(stdout|stderr)\.write" scripts src tests --glob '!node_modules/**'`