### PR TITLE
feat: show farm market days

### DIFF
--- a/src/app/farm/[farmId].tsx
+++ b/src/app/farm/[farmId].tsx
@@ -12,8 +12,10 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { FarmHeroCard } from "../../components/FarmHeroCard";
 import {
   deleteFarmProfile,
+  type FarmMarketDay,
   type FarmProfile,
   fetchFarmProfileById,
+  fetchUpcomingMarketDaysByFarmerId,
 } from "../../lib/farmProfiles";
 import { useAuth } from "../../providers/auth-provider";
 import { farmStyles } from "../../styles/farm-styles";
@@ -27,6 +29,20 @@ function formatTimestamp(value: string): string {
     hour: "2-digit",
     minute: "2-digit",
   });
+}
+
+function formatMarketDate(value: string): string {
+  const [year, month, day] = value.split("-").map(Number);
+  return new Date(year, month - 1, day).toLocaleDateString("en-GB", {
+    weekday: "short",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+function formatMarketTime(value: string): string {
+  return value.slice(0, 5);
 }
 
 // Panel component to display farm details and actions for the owner
@@ -101,20 +117,111 @@ function FarmDetailsPanel({
   );
 }
 
+function UpcomingMarketDaysPanel({
+  marketDays,
+  loading,
+  error,
+}: {
+  marketDays: FarmMarketDay[];
+  loading: boolean;
+  error: string | null;
+}) {
+  return (
+    <View style={farmStyles.panel}>
+      <View style={farmStyles.sectionHeader}>
+        <Text style={farmStyles.panelTitle}>Upcoming market days</Text>
+        <Text style={farmStyles.readonlyMeta}>
+          See where this farm will be selling in person.
+        </Text>
+      </View>
+
+      {loading ? (
+        <View style={farmStyles.inlineStatus}>
+          <ActivityIndicator color="#2F6A3E" />
+          <Text style={farmStyles.readonlyMeta}>Loading market days...</Text>
+        </View>
+      ) : error ? (
+        <Text style={farmStyles.errorText}>{error}</Text>
+      ) : marketDays.length === 0 ? (
+        <Text style={farmStyles.emptyText}>
+          No upcoming market days scheduled.
+        </Text>
+      ) : (
+        <View style={farmStyles.readonlyGrid}>
+          {marketDays.map((marketDay) => (
+            <View key={marketDay.id} style={farmStyles.readonlyItem}>
+              <Text style={farmStyles.rowName}>
+                {formatMarketDate(marketDay.date)}
+              </Text>
+              <Text style={farmStyles.readonlyMeta}>
+                {formatMarketTime(marketDay.start_time)}-
+                {formatMarketTime(marketDay.end_time)}
+              </Text>
+              <Text style={farmStyles.longValue}>{marketDay.location}</Text>
+              {marketDay.notes ? (
+                <Text style={farmStyles.readonlyMeta}>{marketDay.notes}</Text>
+              ) : null}
+            </View>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}
+
 export default function FarmProfileScreen() {
   const { farmId } = useLocalSearchParams<{ farmId: string }>();
   const { user } = useAuth();
   const router = useRouter();
   const [farmProfile, setFarmProfile] = useState<FarmProfile | null>(null);
   const [loading, setLoading] = useState(true);
+  const [marketDays, setMarketDays] = useState<FarmMarketDay[]>([]);
+  const [marketDaysLoading, setMarketDaysLoading] = useState(false);
+  const [marketDaysError, setMarketDaysError] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
+
+    setLoading(true);
+    setFarmProfile(null);
+    setMarketDays([]);
+    setErrorMessage(null);
+    setMarketDaysError(null);
+
     fetchFarmProfileById(farmId)
-      .then(setFarmProfile)
-      .catch((error) => setErrorMessage(error.message))
-      .finally(() => setLoading(false));
+      .then((profile) => {
+        if (cancelled) return;
+        setFarmProfile(profile);
+        setLoading(false);
+
+        if (!profile) return;
+
+        setMarketDaysLoading(true);
+        fetchUpcomingMarketDaysByFarmerId(profile.user_id)
+          .then((days) => {
+            if (!cancelled) setMarketDays(days);
+          })
+          .catch(() => {
+            if (!cancelled) {
+              setMarketDaysError("Unable to load upcoming market days.");
+            }
+          })
+          .finally(() => {
+            if (!cancelled) setMarketDaysLoading(false);
+          });
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setErrorMessage(error.message);
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [farmId]);
 
   const handleDelete = () => {
@@ -173,6 +280,11 @@ export default function FarmProfileScreen() {
         showsVerticalScrollIndicator={false}
       >
         <FarmHeroCard farmProfile={farmProfile} />
+        <UpcomingMarketDaysPanel
+          error={marketDaysError}
+          loading={marketDaysLoading}
+          marketDays={marketDays}
+        />
         <FarmDetailsPanel
           deleting={deleting}
           farmProfile={farmProfile}

--- a/src/lib/farmProfiles.ts
+++ b/src/lib/farmProfiles.ts
@@ -19,6 +19,20 @@ export type FarmProfile = {
   longitude: number | null;
 };
 
+export type FarmMarketDay = {
+  id: string;
+  farmer_id: string;
+  date: string;
+  start_time: string;
+  end_time: string;
+  location: string;
+  notes: string | null;
+};
+
+function dateKey(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+}
+
 export async function fetchFarmProfileByUserId(
   userId: string,
 ): Promise<FarmProfile | null> {
@@ -94,6 +108,25 @@ export async function fetchAllFarmProfiles(): Promise<FarmProfile[]> {
     .from("farm_profiles")
     .select("*")
     .order("farm_name", { ascending: true });
+
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function fetchUpcomingMarketDaysByFarmerId(
+  farmerId: string,
+  limit = 3,
+): Promise<FarmMarketDay[]> {
+  if (!supabase) throw new Error("Supabase is not configured.");
+
+  const { data, error } = await supabase
+    .from("market_days")
+    .select("id, farmer_id, date, start_time, end_time, location, notes")
+    .eq("farmer_id", farmerId)
+    .gte("date", dateKey(new Date()))
+    .order("date", { ascending: true })
+    .order("start_time", { ascending: true })
+    .limit(limit);
 
   if (error) throw error;
   return data ?? [];

--- a/src/styles/farm-styles.tsx
+++ b/src/styles/farm-styles.tsx
@@ -204,6 +204,11 @@ export const farmStyles = StyleSheet.create({
     color: "#5D6A60",
     fontSize: 14,
   },
+  inlineStatus: {
+    alignItems: "center",
+    flexDirection: "row",
+    gap: 10,
+  },
   rowName: {
     color: "#182019",
     fontSize: 15,

--- a/supabase/migrations/202604301945_allow_market_days_profile_read.sql
+++ b/supabase/migrations/202604301945_allow_market_days_profile_read.sql
@@ -1,0 +1,8 @@
+drop policy if exists "market_days_select_own" on public.market_days;
+drop policy if exists "market_days_select_profile_read" on public.market_days;
+
+create policy "market_days_select_profile_read"
+on public.market_days
+for select
+to anon, authenticated
+using (true);

--- a/tests/farm-profile-screen.test.tsx
+++ b/tests/farm-profile-screen.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor } from "@testing-library/react-native";
+
+import FarmProfileScreen from "../src/app/farm/[farmId]";
+
+const mockReplace = jest.fn();
+const mockFetchFarmProfileById = jest.fn();
+const mockFetchUpcomingMarketDaysByFarmerId = jest.fn();
+
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: () => ({ farmId: "farm-1" }),
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+jest.mock("../src/providers/auth-provider", () => ({
+  useAuth: () => ({
+    user: null,
+  }),
+}));
+
+jest.mock("../src/lib/farmProfiles", () => ({
+  deleteFarmProfile: jest.fn(),
+  fetchFarmProfileById: (...args: unknown[]) =>
+    mockFetchFarmProfileById(...args),
+  fetchUpcomingMarketDaysByFarmerId: (...args: unknown[]) =>
+    mockFetchUpcomingMarketDaysByFarmerId(...args),
+}));
+
+const farmProfile = {
+  id: "farm-1",
+  user_id: "farmer-1",
+  farm_name: "Green Valley Farm",
+  farm_location: "Kristiansand",
+  farm_bio: "Seasonal vegetables and berries.",
+  farm_profile_picture_url: null,
+  created_at: "2026-04-01T09:00:00.000Z",
+  updated_at: "2026-04-15T14:30:00.000Z",
+  country: "Norway",
+  region: "Agder",
+  city: "Kristiansand",
+  postal_code: "4610",
+  street: "Market Road 1",
+  latitude: 58.1467,
+  longitude: 7.9956,
+};
+
+describe("FarmProfileScreen", () => {
+  beforeEach(() => {
+    mockReplace.mockReset();
+    mockFetchFarmProfileById.mockReset();
+    mockFetchUpcomingMarketDaysByFarmerId.mockReset();
+  });
+
+  it("renders upcoming market days for the farm profile", async () => {
+    mockFetchFarmProfileById.mockResolvedValue(farmProfile);
+    mockFetchUpcomingMarketDaysByFarmerId.mockResolvedValue([
+      {
+        id: "market-1",
+        farmer_id: "farmer-1",
+        date: "2026-05-09",
+        start_time: "09:00:00",
+        end_time: "13:00:00",
+        location: "Kristiansand Torv",
+        notes: "Find us by the north entrance.",
+      },
+    ]);
+
+    render(<FarmProfileScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Upcoming market days")).toBeTruthy();
+    });
+
+    expect(mockFetchFarmProfileById).toHaveBeenCalledWith("farm-1");
+    expect(mockFetchUpcomingMarketDaysByFarmerId).toHaveBeenCalledWith(
+      "farmer-1",
+    );
+    expect(screen.getByText("Sat, 9 May 2026")).toBeTruthy();
+    expect(screen.getByText("09:00-13:00")).toBeTruthy();
+    expect(screen.getByText("Kristiansand Torv")).toBeTruthy();
+    expect(screen.getByText("Find us by the north entrance.")).toBeTruthy();
+  });
+
+  it("shows an empty state when the farm has no upcoming market days", async () => {
+    mockFetchFarmProfileById.mockResolvedValue(farmProfile);
+    mockFetchUpcomingMarketDaysByFarmerId.mockResolvedValue([]);
+
+    render(<FarmProfileScreen />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No upcoming market days scheduled."),
+      ).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- show upcoming market days on farm profile pages
- add a shared farm-profile helper for upcoming market-day queries
- allow public reads of market days so profile pages can display them
- cover populated and empty market-day states in a farm profile screen test

Closes #24.

## Checks
- `npm run format:check`
- `npm run typecheck`
- `EXPO_NO_TELEMETRY=1 npm run lint`
- `npm test -- --runInBand`
- `rg -n "console\.log\s*\(" --glob '!node_modules/**' --glob '!.git/**'`