### PR TITLE
docs: document Supabase migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 
 # Expo
 .expo/
+supabase/.temp/
 dist/
 web-build/
 coverage/

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -68,6 +68,32 @@ This writes `android/local.properties`, which is intentionally ignored by git be
 
 This compiles the native code and installs the app directly on your device or emulator.
 
+## Supabase migrations
+
+Database changes belong in versioned SQL files under `supabase/migrations/`.
+Do not copy-paste migration files into the Supabase SQL editor during normal development, because the CLI will not know those migrations were already applied.
+
+Before applying migrations to the linked project, inspect the pending list:
+
+```bash
+npx supabase migration list --linked
+npx supabase db push --dry-run --linked
+```
+
+If the dry run looks correct, apply the pending migrations:
+
+```bash
+npx supabase db push --linked
+```
+
+If a migration was already applied manually in the SQL editor, repair the remote migration history before running `db push`:
+
+```bash
+npx supabase migration repair <timestamp> --status applied --linked
+```
+
+See `supabase/migrations/migrations.md` for the full workflow.
+
 ## How to Contribute
 
 ### Reporting Bugs

--- a/supabase/migrations/migrations.md
+++ b/supabase/migrations/migrations.md
@@ -1,0 +1,41 @@
+# Supabase migrations
+
+This directory contains the database schema migrations for FarmConnect. Each file is applied in timestamp order by the Supabase CLI.
+
+## Normal workflow
+
+1. Create or edit a migration file in `supabase/migrations/`.
+2. Review what would be applied:
+
+   ```bash
+   npx supabase migration list --linked
+   npx supabase db push --dry-run --linked
+   ```
+
+3. Apply the pending migrations:
+
+   ```bash
+   npx supabase db push --linked
+   ```
+
+4. Confirm local and remote history match:
+
+   ```bash
+   npx supabase migration list --linked
+   ```
+
+## Avoid SQL editor drift
+
+Pasting a migration into the Supabase SQL editor changes the database, but it does not mark the migration as applied in `supabase_migrations.schema_migrations`. After that, `db push` may try to run the same migration again.
+
+If a migration has already been applied manually, mark it as applied before running `db push`:
+
+```bash
+npx supabase migration repair <timestamp> --status applied --linked
+```
+
+Use the timestamp prefix from the migration filename, for example `202604301945`.
+
+## Generated local files
+
+`supabase/.temp/` is created by the CLI when the project is linked. It contains local connection metadata and should stay untracked.


### PR DESCRIPTION
## Summary
- ignore Supabase CLI local metadata under `supabase/.temp/`
- document the dry-run and push flow in `CONTRIBUTE.md`
- add a migrations guide with migration repair guidance for SQL editor drift

## Checks
- `npm run format:check`
- `git diff --check`
- `git check-ignore -v supabase/.temp/project-ref supabase/.temp/linked-project.json`