### PR TITLE
feat: show farm pickup availability

### DIFF
--- a/src/app/farm/[farmId].tsx
+++ b/src/app/farm/[farmId].tsx
@@ -12,8 +12,10 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { FarmHeroCard } from "../../components/FarmHeroCard";
 import {
   deleteFarmProfile,
+  type FarmPickupDetails,
   type FarmMarketDay,
   type FarmProfile,
+  fetchFarmPickupDetailsByFarmerId,
   fetchFarmProfileById,
   fetchUpcomingMarketDaysByFarmerId,
 } from "../../lib/farmProfiles";
@@ -43,6 +45,10 @@ function formatMarketDate(value: string): string {
 
 function formatMarketTime(value: string): string {
   return value.slice(0, 5);
+}
+
+function formatQuantity(value: number, unit: string): string {
+  return `${Number(value).toLocaleString("en-GB")} ${unit}`;
 }
 
 // Panel component to display farm details and actions for the owner
@@ -117,6 +123,97 @@ function FarmDetailsPanel({
   );
 }
 
+function PickupAvailabilityPanel({
+  details,
+  loading,
+  error,
+}: {
+  details: FarmPickupDetails;
+  loading: boolean;
+  error: string | null;
+}) {
+  const hasInventory = details.inventory.length > 0;
+  const hasSlots = details.slots.length > 0;
+
+  return (
+    <View style={farmStyles.panel}>
+      <View style={farmStyles.sectionHeader}>
+        <Text style={farmStyles.panelTitle}>Pickup availability</Text>
+        <Text style={farmStyles.readonlyMeta}>
+          See produce available for reservation and upcoming pickup windows.
+        </Text>
+      </View>
+
+      {loading ? (
+        <View style={farmStyles.inlineStatus}>
+          <ActivityIndicator color="#2F6A3E" />
+          <Text style={farmStyles.readonlyMeta}>Loading pickup details...</Text>
+        </View>
+      ) : error ? (
+        <Text style={farmStyles.errorText}>{error}</Text>
+      ) : !hasInventory && !hasSlots ? (
+        <Text style={farmStyles.emptyText}>
+          No pickup produce or time slots are currently available.
+        </Text>
+      ) : (
+        <View style={farmStyles.readonlyGrid}>
+          <View style={farmStyles.textBlock}>
+            <Text style={farmStyles.readonlyLabel}>Available produce</Text>
+            {hasInventory ? (
+              <View style={farmStyles.readonlyGrid}>
+                {details.inventory.map((item) => (
+                  <View key={item.id} style={farmStyles.readonlyItem}>
+                    <Text style={farmStyles.rowName}>{item.produce_name}</Text>
+                    <Text style={farmStyles.readonlyMeta}>
+                      {formatQuantity(item.available_quantity, item.unit)}
+                      {item.price_text ? ` - ${item.price_text}` : ""}
+                    </Text>
+                    {item.notes ? (
+                      <Text style={farmStyles.readonlyMeta}>{item.notes}</Text>
+                    ) : null}
+                  </View>
+                ))}
+              </View>
+            ) : (
+              <Text style={farmStyles.emptyText}>
+                No produce is currently listed for pickup.
+              </Text>
+            )}
+          </View>
+
+          <View style={farmStyles.textBlock}>
+            <Text style={farmStyles.readonlyLabel}>Pickup time slots</Text>
+            {hasSlots ? (
+              <View style={farmStyles.readonlyGrid}>
+                {details.slots.map((slot) => (
+                  <View key={slot.id} style={farmStyles.readonlyItem}>
+                    <Text style={farmStyles.rowName}>
+                      {formatMarketDate(slot.slot_date)}
+                    </Text>
+                    <Text style={farmStyles.readonlyMeta}>
+                      {formatMarketTime(slot.start_time)}-
+                      {formatMarketTime(slot.end_time)} - {slot.capacity}{" "}
+                      {slot.capacity === 1 ? "reservation" : "reservations"}
+                    </Text>
+                    <Text style={farmStyles.longValue}>{slot.location}</Text>
+                    {slot.notes ? (
+                      <Text style={farmStyles.readonlyMeta}>{slot.notes}</Text>
+                    ) : null}
+                  </View>
+                ))}
+              </View>
+            ) : (
+              <Text style={farmStyles.emptyText}>
+                No upcoming pickup slots are currently scheduled.
+              </Text>
+            )}
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}
+
 function UpcomingMarketDaysPanel({
   marketDays,
   loading,
@@ -175,6 +272,14 @@ export default function FarmProfileScreen() {
   const router = useRouter();
   const [farmProfile, setFarmProfile] = useState<FarmProfile | null>(null);
   const [loading, setLoading] = useState(true);
+  const [pickupDetails, setPickupDetails] = useState<FarmPickupDetails>({
+    inventory: [],
+    slots: [],
+  });
+  const [pickupDetailsLoading, setPickupDetailsLoading] = useState(false);
+  const [pickupDetailsError, setPickupDetailsError] = useState<string | null>(
+    null,
+  );
   const [marketDays, setMarketDays] = useState<FarmMarketDay[]>([]);
   const [marketDaysLoading, setMarketDaysLoading] = useState(false);
   const [marketDaysError, setMarketDaysError] = useState<string | null>(null);
@@ -186,8 +291,10 @@ export default function FarmProfileScreen() {
 
     setLoading(true);
     setFarmProfile(null);
+    setPickupDetails({ inventory: [], slots: [] });
     setMarketDays([]);
     setErrorMessage(null);
+    setPickupDetailsError(null);
     setMarketDaysError(null);
 
     fetchFarmProfileById(farmId)
@@ -199,6 +306,7 @@ export default function FarmProfileScreen() {
         if (!profile) return;
 
         setMarketDaysLoading(true);
+        setPickupDetailsLoading(true);
         fetchUpcomingMarketDaysByFarmerId(profile.user_id)
           .then((days) => {
             if (!cancelled) setMarketDays(days);
@@ -210,6 +318,18 @@ export default function FarmProfileScreen() {
           })
           .finally(() => {
             if (!cancelled) setMarketDaysLoading(false);
+          });
+        fetchFarmPickupDetailsByFarmerId(profile.user_id)
+          .then((details) => {
+            if (!cancelled) setPickupDetails(details);
+          })
+          .catch(() => {
+            if (!cancelled) {
+              setPickupDetailsError("Unable to load pickup availability.");
+            }
+          })
+          .finally(() => {
+            if (!cancelled) setPickupDetailsLoading(false);
           });
       })
       .catch((error) => {
@@ -280,6 +400,11 @@ export default function FarmProfileScreen() {
         showsVerticalScrollIndicator={false}
       >
         <FarmHeroCard farmProfile={farmProfile} />
+        <PickupAvailabilityPanel
+          details={pickupDetails}
+          error={pickupDetailsError}
+          loading={pickupDetailsLoading}
+        />
         <UpcomingMarketDaysPanel
           error={marketDaysError}
           loading={marketDaysLoading}

--- a/src/lib/farmProfiles.ts
+++ b/src/lib/farmProfiles.ts
@@ -29,6 +29,34 @@ export type FarmMarketDay = {
   notes: string | null;
 };
 
+export type FarmPickupInventoryItem = {
+  id: string;
+  farmer_id: string;
+  produce_id: string | null;
+  produce_name: string;
+  available_quantity: number;
+  unit: string;
+  price_text: string | null;
+  notes: string | null;
+  is_available: boolean;
+};
+
+export type FarmPickupSlot = {
+  id: string;
+  farmer_id: string;
+  slot_date: string;
+  start_time: string;
+  end_time: string;
+  capacity: number;
+  location: string;
+  notes: string | null;
+};
+
+export type FarmPickupDetails = {
+  inventory: FarmPickupInventoryItem[];
+  slots: FarmPickupSlot[];
+};
+
 function dateKey(date: Date): string {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
 }
@@ -130,6 +158,45 @@ export async function fetchUpcomingMarketDaysByFarmerId(
 
   if (error) throw error;
   return data ?? [];
+}
+
+export async function fetchFarmPickupDetailsByFarmerId(
+  farmerId: string,
+  limit = 4,
+): Promise<FarmPickupDetails> {
+  if (!supabase) throw new Error("Supabase is not configured.");
+
+  const today = dateKey(new Date());
+  const [inventoryResult, slotsResult] = await Promise.all([
+    supabase
+      .from("pickup_inventory")
+      .select(
+        "id, farmer_id, produce_id, produce_name, available_quantity, unit, price_text, notes, is_available",
+      )
+      .eq("farmer_id", farmerId)
+      .eq("is_available", true)
+      .gt("available_quantity", 0)
+      .order("produce_name", { ascending: true })
+      .limit(limit),
+    supabase
+      .from("pickup_time_slots")
+      .select(
+        "id, farmer_id, slot_date, start_time, end_time, capacity, location, notes",
+      )
+      .eq("farmer_id", farmerId)
+      .gte("slot_date", today)
+      .order("slot_date", { ascending: true })
+      .order("start_time", { ascending: true })
+      .limit(limit),
+  ]);
+
+  if (inventoryResult.error) throw inventoryResult.error;
+  if (slotsResult.error) throw slotsResult.error;
+
+  return {
+    inventory: inventoryResult.data ?? [],
+    slots: slotsResult.data ?? [],
+  };
 }
 
 export async function deleteFarmProfile(userId: string): Promise<void> {

--- a/supabase/migrations/202605010030_allow_pickup_profile_read.sql
+++ b/supabase/migrations/202605010030_allow_pickup_profile_read.sql
@@ -1,0 +1,13 @@
+drop policy if exists "pickup_inventory_select_profile_read" on public.pickup_inventory;
+create policy "pickup_inventory_select_profile_read"
+on public.pickup_inventory
+for select
+to anon, authenticated
+using (is_available = true and available_quantity > 0);
+
+drop policy if exists "pickup_time_slots_select_profile_read" on public.pickup_time_slots;
+create policy "pickup_time_slots_select_profile_read"
+on public.pickup_time_slots
+for select
+to anon, authenticated
+using (slot_date >= current_date);

--- a/tests/farm-profile-screen.test.tsx
+++ b/tests/farm-profile-screen.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react-native";
 import FarmProfileScreen from "../src/app/farm/[farmId]";
 
 const mockReplace = jest.fn();
+const mockFetchFarmPickupDetailsByFarmerId = jest.fn();
 const mockFetchFarmProfileById = jest.fn();
 const mockFetchUpcomingMarketDaysByFarmerId = jest.fn();
 
@@ -19,6 +20,8 @@ jest.mock("../src/providers/auth-provider", () => ({
 
 jest.mock("../src/lib/farmProfiles", () => ({
   deleteFarmProfile: jest.fn(),
+  fetchFarmPickupDetailsByFarmerId: (...args: unknown[]) =>
+    mockFetchFarmPickupDetailsByFarmerId(...args),
   fetchFarmProfileById: (...args: unknown[]) =>
     mockFetchFarmProfileById(...args),
   fetchUpcomingMarketDaysByFarmerId: (...args: unknown[]) =>
@@ -46,12 +49,45 @@ const farmProfile = {
 describe("FarmProfileScreen", () => {
   beforeEach(() => {
     mockReplace.mockReset();
+    mockFetchFarmPickupDetailsByFarmerId.mockReset();
     mockFetchFarmProfileById.mockReset();
     mockFetchUpcomingMarketDaysByFarmerId.mockReset();
+    mockFetchFarmPickupDetailsByFarmerId.mockResolvedValue({
+      inventory: [],
+      slots: [],
+    });
+    mockFetchUpcomingMarketDaysByFarmerId.mockResolvedValue([]);
   });
 
-  it("renders upcoming market days for the farm profile", async () => {
+  it("renders pickup availability and upcoming market days for the farm profile", async () => {
     mockFetchFarmProfileById.mockResolvedValue(farmProfile);
+    mockFetchFarmPickupDetailsByFarmerId.mockResolvedValue({
+      inventory: [
+        {
+          id: "inventory-1",
+          farmer_id: "farmer-1",
+          produce_id: "carrots",
+          produce_name: "Carrots",
+          available_quantity: 12,
+          unit: "kg",
+          price_text: "40 kr/kg",
+          notes: "Washed and bundled.",
+          is_available: true,
+        },
+      ],
+      slots: [
+        {
+          id: "slot-1",
+          farmer_id: "farmer-1",
+          slot_date: "2026-05-10",
+          start_time: "14:00:00",
+          end_time: "16:00:00",
+          capacity: 5,
+          location: "Farm gate",
+          notes: "Ring the bell at the red barn.",
+        },
+      ],
+    });
     mockFetchUpcomingMarketDaysByFarmerId.mockResolvedValue([
       {
         id: "market-1",
@@ -71,9 +107,20 @@ describe("FarmProfileScreen", () => {
     });
 
     expect(mockFetchFarmProfileById).toHaveBeenCalledWith("farm-1");
+    expect(mockFetchFarmPickupDetailsByFarmerId).toHaveBeenCalledWith(
+      "farmer-1",
+    );
     expect(mockFetchUpcomingMarketDaysByFarmerId).toHaveBeenCalledWith(
       "farmer-1",
     );
+    expect(screen.getByText("Pickup availability")).toBeTruthy();
+    expect(screen.getByText("Carrots")).toBeTruthy();
+    expect(screen.getByText("12 kg - 40 kr/kg")).toBeTruthy();
+    expect(screen.getByText("Washed and bundled.")).toBeTruthy();
+    expect(screen.getByText("Sun, 10 May 2026")).toBeTruthy();
+    expect(screen.getByText("14:00-16:00 - 5 reservations")).toBeTruthy();
+    expect(screen.getByText("Farm gate")).toBeTruthy();
+    expect(screen.getByText("Ring the bell at the red barn.")).toBeTruthy();
     expect(screen.getByText("Sat, 9 May 2026")).toBeTruthy();
     expect(screen.getByText("09:00-13:00")).toBeTruthy();
     expect(screen.getByText("Kristiansand Torv")).toBeTruthy();
@@ -82,11 +129,15 @@ describe("FarmProfileScreen", () => {
 
   it("shows an empty state when the farm has no upcoming market days", async () => {
     mockFetchFarmProfileById.mockResolvedValue(farmProfile);
-    mockFetchUpcomingMarketDaysByFarmerId.mockResolvedValue([]);
 
     render(<FarmProfileScreen />);
 
     await waitFor(() => {
+      expect(
+        screen.getByText(
+          "No pickup produce or time slots are currently available.",
+        ),
+      ).toBeTruthy();
       expect(
         screen.getByText("No upcoming market days scheduled."),
       ).toBeTruthy();


### PR DESCRIPTION
## Summary
- show available pickup produce and upcoming pickup slots on farm profile pages
- add shared farm-profile helpers for pickup inventory and slot queries
- add public read policies for available pickup inventory and upcoming pickup slots while keeping farmer owner policies intact
- cover populated and empty pickup states in the farm profile screen test

Closes #26.

## Checks
- `npm run format:check`
- `npm run typecheck`
- `EXPO_NO_TELEMETRY=1 npm run lint`
- `npm test -- --runInBand`
- `npx supabase db push --dry-run --linked`
- `rg -n "console\.log\s*\(" --glob '!node_modules/**' --glob '!.git/**'`