### PR TITLE
Add searchable farm list controls

### DIFF
--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -2,9 +2,8 @@ import { useRouter, type Href } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { Animated, Pressable, ScrollView, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { FarmList } from "../components/FarmList";
 import produceData from "../data/produceData.json";
-import { useAllFarmProfiles, useFarmProfile } from "../hooks/useFarmProfile";
+import { useFarmProfile } from "../hooks/useFarmProfile";
 import { useAuth } from "../providers/auth-provider";
 import { homeStyles } from "../styles/home-styles";
 
@@ -41,7 +40,6 @@ function ScaleButton({
 export default function Index() {
   const { session, user, profile } = useAuth();
   const { farmProfile } = useFarmProfile(user?.id);
-  const { farms, loading: farmsLoading } = useAllFarmProfiles();
   const router = useRouter();
 
   const firstName = user?.email?.split("@")[0] ?? null;
@@ -112,9 +110,6 @@ export default function Index() {
                 See all produce
               </ScaleButton>
             </View>
-
-            {/* Farms */}
-            <FarmList farms={farms} loading={farmsLoading} />
 
             {/* Account */}
             <View style={homeStyles.sectionCard}>

--- a/src/app/map.tsx
+++ b/src/app/map.tsx
@@ -1,20 +1,50 @@
+import { FarmList } from "@/components/FarmList";
 import { useAllFarmProfiles } from "@/hooks/useFarmProfile";
+import type { FarmProfile } from "@/lib/farmProfiles";
 import { useRouter } from "expo-router";
+import { useCallback, useRef, useState } from "react";
 import { StyleSheet, View } from "react-native";
 import MapView, { Marker, PROVIDER_GOOGLE } from "react-native-maps";
 
 export default function MapScreen() {
   const router = useRouter();
+  const mapRef = useRef<MapView>(null);
+  const [searchExpanded, setSearchExpanded] = useState(false);
 
-  const { farms } = useAllFarmProfiles();
+  const { farms, loading } = useAllFarmProfiles();
 
   const farmsWithCoordinates = farms.filter(
     (farm) => farm.latitude !== null && farm.longitude !== null,
   );
 
+  const focusFirstResult = useCallback(
+    (farm: FarmProfile | null) => {
+      if (
+        !searchExpanded ||
+        !farm ||
+        farm.latitude === null ||
+        farm.longitude === null
+      ) {
+        return;
+      }
+
+      mapRef.current?.animateToRegion(
+        {
+          latitude: farm.latitude,
+          longitude: farm.longitude,
+          latitudeDelta: 0.18,
+          longitudeDelta: 0.18,
+        },
+        450,
+      );
+    },
+    [searchExpanded],
+  );
+
   return (
     <View style={styles.container}>
       <MapView
+        ref={mapRef}
         provider={PROVIDER_GOOGLE}
         style={styles.map}
         // Setting the start position for the map, and zoom level. Approximately Kristiansand / Grimstad
@@ -42,6 +72,22 @@ export default function MapScreen() {
           ) : null,
         )}
       </MapView>
+      <View
+        pointerEvents="box-none"
+        style={[
+          styles.searchOverlay,
+          searchExpanded && styles.searchOverlayExpanded,
+        ]}
+      >
+        <FarmList
+          collapsed={!searchExpanded}
+          farms={farms}
+          loading={loading}
+          onCollapse={() => setSearchExpanded(false)}
+          onExpand={() => setSearchExpanded(true)}
+          onFirstResultChange={focusFirstResult}
+        />
+      </View>
     </View>
   );
 }
@@ -52,5 +98,14 @@ const styles = StyleSheet.create({
   },
   map: {
     ...StyleSheet.absoluteFillObject,
+  },
+  searchOverlay: {
+    left: 16,
+    position: "absolute",
+    right: 16,
+    top: 56,
+  },
+  searchOverlayExpanded: {
+    bottom: 24,
   },
 });

--- a/src/components/FarmList.tsx
+++ b/src/components/FarmList.tsx
@@ -1,8 +1,9 @@
 import { Link, type Href } from "expo-router";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   Pressable,
+  ScrollView,
   Text,
   TextInput,
   View,
@@ -13,23 +14,152 @@ import { farmStyles } from "../styles/farm-styles";
 type Props = {
   farms: FarmProfile[];
   loading: boolean;
+  collapsed?: boolean;
+  onCollapse?: () => void;
+  onExpand?: () => void;
+  onFirstResultChange?: (farm: FarmProfile | null) => void;
 };
 
-export function FarmList({ farms, loading }: Props) {
-  const [query, setQuery] = useState("");
+type SortMode = "distance" | "name" | "location";
+type RadiusKm = 50 | 100 | "all";
 
-  const filtered = query.trim()
-    ? farms.filter(
-        (f) =>
-          f.farm_name.toLowerCase().includes(query.toLowerCase()) ||
-          (f.farm_location ?? "").toLowerCase().includes(query.toLowerCase()),
-      )
-    : farms;
+const DEFAULT_CENTER = {
+  latitude: 58.1467,
+  longitude: 7.9956,
+};
+
+const SORT_OPTIONS: { label: string; value: SortMode }[] = [
+  { label: "Nearest", value: "distance" },
+  { label: "Name", value: "name" },
+  { label: "Location", value: "location" },
+];
+
+const RADIUS_OPTIONS: { label: string; value: RadiusKm }[] = [
+  { label: "50 km", value: 50 },
+  { label: "100 km", value: 100 },
+  { label: "All", value: "all" },
+];
+
+function distanceKm(farm: FarmProfile): number | null {
+  if (farm.latitude === null || farm.longitude === null) return null;
+
+  const earthRadiusKm = 6371;
+  const toRadians = (degrees: number) => (degrees * Math.PI) / 180;
+  const latDelta = toRadians(farm.latitude - DEFAULT_CENTER.latitude);
+  const lonDelta = toRadians(farm.longitude - DEFAULT_CENTER.longitude);
+  const originLat = toRadians(DEFAULT_CENTER.latitude);
+  const farmLat = toRadians(farm.latitude);
+  const a =
+    Math.sin(latDelta / 2) ** 2 +
+    Math.cos(originLat) * Math.cos(farmLat) * Math.sin(lonDelta / 2) ** 2;
+
+  return earthRadiusKm * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function searchableText(farm: FarmProfile): string {
+  return [
+    farm.farm_name,
+    farm.farm_location,
+    farm.city,
+    farm.region,
+    farm.country,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+function compareNullableText(left: string | null, right: string | null) {
+  return (left ?? "").localeCompare(right ?? "");
+}
+
+export function FarmList({
+  farms,
+  loading,
+  collapsed = false,
+  onCollapse,
+  onExpand,
+  onFirstResultChange,
+}: Props) {
+  const [query, setQuery] = useState("");
+  const [sortMode, setSortMode] = useState<SortMode>("distance");
+  const [radiusKm, setRadiusKm] = useState<RadiusKm>(100);
+
+  const filtered = useMemo(() => {
+    const trimmedQuery = query.trim().toLowerCase();
+
+    return farms
+      .map((farm) => ({ farm, distance: distanceKm(farm) }))
+      .filter(({ farm, distance }) => {
+        const matchesQuery =
+          !trimmedQuery || searchableText(farm).includes(trimmedQuery);
+        const matchesRadius =
+          radiusKm === "all" || (distance !== null && distance <= radiusKm);
+
+        return matchesQuery && matchesRadius;
+      })
+      .sort((left, right) => {
+        if (sortMode === "name") {
+          return left.farm.farm_name.localeCompare(right.farm.farm_name);
+        }
+
+        if (sortMode === "location") {
+          return (
+            compareNullableText(
+              left.farm.farm_location,
+              right.farm.farm_location,
+            ) || left.farm.farm_name.localeCompare(right.farm.farm_name)
+          );
+        }
+
+        return (
+          (left.distance ?? Number.POSITIVE_INFINITY) -
+            (right.distance ?? Number.POSITIVE_INFINITY) ||
+          left.farm.farm_name.localeCompare(right.farm.farm_name)
+        );
+      });
+  }, [farms, query, radiusKm, sortMode]);
+
+  const activeRadiusLabel =
+    radiusKm === "all" ? "all distances" : `within ${radiusKm} km`;
+
+  useEffect(() => {
+    if (!onFirstResultChange) return;
+    onFirstResultChange(loading ? null : (filtered[0]?.farm ?? null));
+  }, [filtered, loading, onFirstResultChange]);
+
+  if (collapsed) {
+    return (
+      <Pressable
+        accessibilityRole="button"
+        onPress={onExpand}
+        style={farmStyles.mapSearchBar}
+        testID="farm-search-bar"
+      >
+        <Text style={farmStyles.mapSearchPlaceholder}>
+          Search farms or locations
+        </Text>
+      </Pressable>
+    );
+  }
 
   return (
     <View style={farmStyles.panel}>
-      <Text style={farmStyles.listEyebrow}>Farms</Text>
-      <Text style={farmStyles.panelTitle}>Browse registered farms</Text>
+      <View style={farmStyles.panelHeaderRow}>
+        <View style={farmStyles.panelHeaderCopy}>
+          <Text style={farmStyles.listEyebrow}>Farms</Text>
+          <Text style={farmStyles.panelTitle}>Browse registered farms</Text>
+        </View>
+        {onCollapse ? (
+          <Pressable
+            accessibilityRole="button"
+            onPress={onCollapse}
+            style={farmStyles.closeButton}
+          >
+            <Text style={farmStyles.closeButtonText}>Close</Text>
+          </Pressable>
+        ) : null}
+      </View>
       <TextInput
         onChangeText={setQuery}
         placeholder="Search by name or location"
@@ -37,23 +167,93 @@ export function FarmList({ farms, loading }: Props) {
         style={farmStyles.searchInput}
         value={query}
       />
+      <View style={farmStyles.filterGroup}>
+        <Text style={farmStyles.filterLabel}>Sort</Text>
+        <View style={farmStyles.filterRow}>
+          {SORT_OPTIONS.map((option) => (
+            <Pressable
+              key={option.value}
+              accessibilityRole="button"
+              onPress={() => setSortMode(option.value)}
+              style={[
+                farmStyles.filterChip,
+                sortMode === option.value && farmStyles.filterChipActive,
+              ]}
+            >
+              <Text
+                style={[
+                  farmStyles.filterChipText,
+                  sortMode === option.value && farmStyles.filterChipTextActive,
+                ]}
+              >
+                {option.label}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+      </View>
+      <View style={farmStyles.filterGroup}>
+        <Text style={farmStyles.filterLabel}>Distance</Text>
+        <View style={farmStyles.filterRow}>
+          {RADIUS_OPTIONS.map((option) => (
+            <Pressable
+              key={option.value}
+              accessibilityRole="button"
+              onPress={() => setRadiusKm(option.value)}
+              style={[
+                farmStyles.filterChip,
+                radiusKm === option.value && farmStyles.filterChipActive,
+              ]}
+            >
+              <Text
+                style={[
+                  farmStyles.filterChipText,
+                  radiusKm === option.value && farmStyles.filterChipTextActive,
+                ]}
+              >
+                {option.label}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+      </View>
       {loading ? (
         <ActivityIndicator color="#2F6A3E" />
       ) : filtered.length === 0 ? (
         <Text style={farmStyles.emptyText}>No farms found.</Text>
       ) : (
-        filtered.map((farm) => (
-          <Link key={farm.id} href={`/farm/${farm.id}` as Href} asChild>
-            <Pressable style={farmStyles.readonlyItem}>
-              <Text style={farmStyles.rowName}>{farm.farm_name}</Text>
-              {farm.farm_location ? (
-                <Text style={farmStyles.readonlyMeta}>
-                  {farm.farm_location}
-                </Text>
-              ) : null}
-            </Pressable>
-          </Link>
-        ))
+        <>
+          <Text style={farmStyles.resultMeta}>
+            Showing {filtered.length} of {farms.length} farms,{" "}
+            {activeRadiusLabel}
+          </Text>
+          <ScrollView
+            contentContainerStyle={farmStyles.resultListContent}
+            showsVerticalScrollIndicator={false}
+            style={farmStyles.resultList}
+          >
+            {filtered.map(({ farm, distance }) => (
+              <Link key={farm.id} href={`/farm/${farm.id}` as Href} asChild>
+                <Pressable
+                  style={farmStyles.readonlyItem}
+                  testID="farm-list-item"
+                >
+                  <Text style={farmStyles.rowName}>{farm.farm_name}</Text>
+                  {farm.farm_location ? (
+                    <Text style={farmStyles.readonlyMeta}>
+                      {farm.farm_location}
+                    </Text>
+                  ) : null}
+                  {distance !== null ? (
+                    <Text style={farmStyles.readonlyMeta}>
+                      {Math.round(distance)} km from Kristiansand
+                    </Text>
+                  ) : null}
+                </Pressable>
+              </Link>
+            ))}
+          </ScrollView>
+        </>
       )}
     </View>
   );

--- a/src/styles/farm-styles.tsx
+++ b/src/styles/farm-styles.tsx
@@ -65,6 +65,16 @@ export const farmStyles = StyleSheet.create({
     padding: 18,
     ...shadow,
   },
+  panelHeaderRow: {
+    alignItems: "flex-start",
+    flexDirection: "row",
+    gap: 12,
+    justifyContent: "space-between",
+  },
+  panelHeaderCopy: {
+    flex: 1,
+    gap: 4,
+  },
   sectionHeader: {
     gap: 12,
   },
@@ -115,6 +125,17 @@ export const farmStyles = StyleSheet.create({
     color: "#214C2D",
     fontSize: 13,
     fontWeight: "700",
+  },
+  closeButton: {
+    backgroundColor: "#EEF5EB",
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  closeButtonText: {
+    color: "#214C2D",
+    fontSize: 12,
+    fontWeight: "800",
   },
   card: {
     backgroundColor: "#FFFFFF",
@@ -199,6 +220,66 @@ export const farmStyles = StyleSheet.create({
     fontSize: 15,
     paddingHorizontal: 16,
     paddingVertical: 12,
+  },
+  mapSearchBar: {
+    backgroundColor: "#FFFFFF",
+    borderColor: "#D7E2D3",
+    borderRadius: 22,
+    borderWidth: 1,
+    minHeight: 52,
+    justifyContent: "center",
+    paddingHorizontal: 18,
+    ...shadow,
+  },
+  mapSearchPlaceholder: {
+    color: "#445148",
+    fontSize: 15,
+    fontWeight: "700",
+  },
+  filterGroup: {
+    gap: 8,
+  },
+  filterLabel: {
+    color: "#5D6A60",
+    fontSize: 12,
+    fontWeight: "700",
+    letterSpacing: 0.3,
+    textTransform: "uppercase",
+  },
+  filterRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  filterChip: {
+    backgroundColor: "#F7FBF5",
+    borderColor: "#D7E2D3",
+    borderRadius: 999,
+    borderWidth: 1,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  filterChipActive: {
+    backgroundColor: "#21432D",
+    borderColor: "#21432D",
+  },
+  filterChipText: {
+    color: "#445148",
+    fontSize: 13,
+    fontWeight: "700",
+  },
+  filterChipTextActive: {
+    color: "#FFFFFF",
+  },
+  resultMeta: {
+    color: "#5D6A60",
+    fontSize: 13,
+  },
+  resultList: {
+    maxHeight: 360,
+  },
+  resultListContent: {
+    gap: 10,
   },
   emptyText: {
     color: "#5D6A60",

--- a/supabase/migrations/202605050010_seed_demo_farms.sql
+++ b/supabase/migrations/202605050010_seed_demo_farms.sql
@@ -1,0 +1,171 @@
+create temporary table demo_farm_seed (
+  fallback_user_id uuid primary key,
+  email text not null unique,
+  farm_name text not null,
+  farm_bio text not null,
+  farm_location text not null,
+  region text not null,
+  city text not null,
+  postal_code text not null,
+  street text not null,
+  latitude numeric not null,
+  longitude numeric not null
+) on commit drop;
+
+insert into demo_farm_seed (
+  fallback_user_id,
+  email,
+  farm_name,
+  farm_bio,
+  farm_location,
+  region,
+  city,
+  postal_code,
+  street,
+  latitude,
+  longitude
+)
+values
+  (
+    '11111111-1111-4111-8111-111111111111',
+    'kristiansand.farm@example.com',
+    'Kristiansand Market Farm',
+    'Local demo farm near the default map center.',
+    'Kristiansand',
+    'Agder',
+    'Kristiansand',
+    '4610',
+    'Markens gate 1',
+    58.1467,
+    7.9956
+  ),
+  (
+    '22222222-2222-4222-8222-222222222222',
+    'grimstad.farm@example.com',
+    'Grimstad Herb Garden',
+    'Nearby demo farm for radius filtering.',
+    'Grimstad',
+    'Agder',
+    'Grimstad',
+    '4878',
+    'Herb Road 2',
+    58.3405,
+    8.5934
+  ),
+  (
+    '33333333-3333-4333-8333-333333333333',
+    'arendal.farm@example.com',
+    'Arendal Apple Orchard',
+    'Mid-distance demo farm for sorting and search checks.',
+    'Arendal',
+    'Agder',
+    'Arendal',
+    '4836',
+    'Orchard Road 3',
+    58.4615,
+    8.7725
+  ),
+  (
+    '44444444-4444-4444-8444-444444444444',
+    'bergen.farm@example.com',
+    'Bergen Berry Farm',
+    'Far-away demo farm that should appear when all distances are shown.',
+    'Bergen',
+    'Vestland',
+    'Bergen',
+    '5003',
+    'Berry Road 4',
+    60.3913,
+    5.3221
+  );
+
+insert into auth.users (
+  id,
+  aud,
+  role,
+  email,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at
+)
+select
+  fallback_user_id,
+  'authenticated',
+  'authenticated',
+  email,
+  now(),
+  '{"provider": "email", "providers": ["email"]}'::jsonb,
+  jsonb_build_object('full_name', farm_name, 'role', 'farmer'),
+  now(),
+  now()
+from demo_farm_seed seed
+where not exists (
+  select 1
+  from auth.users users
+  where lower(users.email) = lower(seed.email)
+)
+on conflict (id) do update
+  set email = excluded.email,
+      raw_user_meta_data = excluded.raw_user_meta_data,
+      updated_at = now();
+
+insert into public.profiles (
+  id,
+  email,
+  full_name,
+  role
+)
+select
+  users.id,
+  seed.email,
+  seed.farm_name,
+  'farmer'
+from demo_farm_seed seed
+join auth.users users on lower(users.email) = lower(seed.email)
+on conflict (id) do update
+  set email = excluded.email,
+      full_name = excluded.full_name,
+      role = excluded.role,
+      updated_at = now();
+
+insert into public.farm_profiles (
+  user_id,
+  farm_name,
+  farm_bio,
+  farm_location,
+  country,
+  region,
+  city,
+  postal_code,
+  street,
+  latitude,
+  longitude
+)
+select
+  users.id,
+  seed.farm_name,
+  seed.farm_bio,
+  seed.farm_location,
+  'Norway',
+  seed.region,
+  seed.city,
+  seed.postal_code,
+  seed.street,
+  seed.latitude,
+  seed.longitude
+from demo_farm_seed seed
+join auth.users users on lower(users.email) = lower(seed.email)
+on conflict (user_id) do update
+  set farm_name = excluded.farm_name,
+      farm_bio = excluded.farm_bio,
+      farm_location = excluded.farm_location,
+      country = excluded.country,
+      region = excluded.region,
+      city = excluded.city,
+      postal_code = excluded.postal_code,
+      street = excluded.street,
+      latitude = excluded.latitude,
+      longitude = excluded.longitude,
+      updated_at = now();

--- a/tests/farm-list.test.tsx
+++ b/tests/farm-list.test.tsx
@@ -1,0 +1,160 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react-native";
+
+import { FarmList } from "../src/components/FarmList";
+import type { FarmProfile } from "../src/lib/farmProfiles";
+
+jest.mock("expo-router", () => {
+  const React = require("react");
+  const { Text } = require("react-native");
+
+  return {
+    Link: ({ children }: { children: React.ReactNode }) => (
+      <Text>{children}</Text>
+    ),
+  };
+});
+
+const farms: FarmProfile[] = [
+  {
+    id: "farm-1",
+    user_id: "farmer-1",
+    farm_name: "Green Valley Farm",
+    farm_location: "Kristiansand",
+    farm_bio: null,
+    farm_profile_picture_url: null,
+    created_at: "2026-04-01T09:00:00.000Z",
+    updated_at: "2026-04-15T14:30:00.000Z",
+    country: "Norway",
+    region: "Agder",
+    city: "Kristiansand",
+    postal_code: "4610",
+    street: "Market Road 1",
+    latitude: 58.1467,
+    longitude: 7.9956,
+  },
+  {
+    id: "farm-2",
+    user_id: "farmer-2",
+    farm_name: "Hilltop Herbs",
+    farm_location: "Grimstad",
+    farm_bio: null,
+    farm_profile_picture_url: null,
+    created_at: "2026-04-02T09:00:00.000Z",
+    updated_at: "2026-04-16T14:30:00.000Z",
+    country: "Norway",
+    region: "Agder",
+    city: "Grimstad",
+    postal_code: "4878",
+    street: "Herb Road 2",
+    latitude: 58.3405,
+    longitude: 8.5934,
+  },
+  {
+    id: "farm-3",
+    user_id: "farmer-3",
+    farm_name: "Bergen Berry Farm",
+    farm_location: "Bergen",
+    farm_bio: null,
+    farm_profile_picture_url: null,
+    created_at: "2026-04-03T09:00:00.000Z",
+    updated_at: "2026-04-17T14:30:00.000Z",
+    country: "Norway",
+    region: "Vestland",
+    city: "Bergen",
+    postal_code: "5003",
+    street: "Berry Road 3",
+    latitude: 60.3913,
+    longitude: 5.3221,
+  },
+];
+
+function visibleFarmNames() {
+  return screen
+    .getAllByTestId("farm-list-item")
+    .map((item) => within(item).getByText(/Farm|Herbs/).props.children);
+}
+
+describe("FarmList", () => {
+  it("defaults to nearby farms and hides farms outside the radius", () => {
+    render(<FarmList farms={farms} loading={false} />);
+
+    expect(
+      screen.getByText("Showing 2 of 3 farms, within 100 km"),
+    ).toBeTruthy();
+    expect(screen.getByText("Green Valley Farm")).toBeTruthy();
+    expect(screen.getByText("Hilltop Herbs")).toBeTruthy();
+    expect(screen.queryByText("Bergen Berry Farm")).toBeNull();
+  });
+
+  it("filters farms by name, location, and region", () => {
+    render(<FarmList farms={farms} loading={false} />);
+
+    fireEvent.changeText(
+      screen.getByPlaceholderText("Search by name or location"),
+      "agder",
+    );
+
+    expect(screen.getByText("Green Valley Farm")).toBeTruthy();
+    expect(screen.getByText("Hilltop Herbs")).toBeTruthy();
+    expect(screen.queryByText("Bergen Berry Farm")).toBeNull();
+  });
+
+  it("can show all distances and sort the visible farms by location", () => {
+    render(<FarmList farms={farms} loading={false} />);
+
+    fireEvent.press(screen.getByText("All"));
+    fireEvent.press(screen.getByText("Location"));
+
+    expect(
+      screen.getByText("Showing 3 of 3 farms, all distances"),
+    ).toBeTruthy();
+    expect(visibleFarmNames()).toEqual([
+      "Bergen Berry Farm",
+      "Hilltop Herbs",
+      "Green Valley Farm",
+    ]);
+  });
+
+  it("renders as a compact map search bar", () => {
+    const onExpand = jest.fn();
+
+    render(
+      <FarmList collapsed farms={farms} loading={false} onExpand={onExpand} />,
+    );
+
+    fireEvent.press(screen.getByTestId("farm-search-bar"));
+
+    expect(onExpand).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports the first visible result when filters change", async () => {
+    const onFirstResultChange = jest.fn();
+
+    render(
+      <FarmList
+        farms={farms}
+        loading={false}
+        onFirstResultChange={onFirstResultChange}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(onFirstResultChange).toHaveBeenCalledWith(farms[0]),
+    );
+
+    fireEvent.changeText(
+      screen.getByPlaceholderText("Search by name or location"),
+      "grimstad",
+    );
+
+    await waitFor(() =>
+      expect(onFirstResultChange).toHaveBeenLastCalledWith(farms[1]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Moves the farm browser controls into the map experience for issue #27:
- adds a compact search bar overlay on the map that expands into the full farm browser
- keeps nearby radius filtering, all-distance mode, result counts, and sort controls
- animates the map to the first visible farm when search/filter results change
- removes the farm browser card from the home screen
- seeds demo farms for emulator testing across nearby and far-away locations
- adds focused FarmList tests for radius filtering, text search, sorting, compact mode, and first-result reporting

Closes #27.

## Showcase
Search bar added on map.
<img width="527" height="1165" alt="image" src="https://github.com/user-attachments/assets/2c98c3a8-91fc-4bac-9747-e332ebd684df" />

Expands into the menu when selected.
<img width="527" height="1165" alt="image" src="https://github.com/user-attachments/assets/83ce08d5-8db2-48c0-a354-98dddd087ea4" />

Searching for a farm navigates to the top result on the map.
<img width="527" height="1165" alt="image" src="https://github.com/user-attachments/assets/905a6c4b-d29e-4aee-83f1-089dd557839f" />

Selecting a farm navigates to the farm profile.
<img width="527" height="1165" alt="image" src="https://github.com/user-attachments/assets/492bc2fd-755c-4ff7-8aa9-8deaf7b2cbe5" />

## Checks

- npm run typecheck
- npm run lint
- npm run format:check
- npm test -- --runInBand