### PR TITLE
Add forgot password flow

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -7,6 +7,20 @@ import { usePushNotifications } from "../hooks/usePushNotifications";
 import { AuthProvider, useAuth } from "../providers/auth-provider";
 import { CartProvider, useCart } from "../providers/cart-provider";
 
+const AUTH_ROUTES = [
+  "/auth/login",
+  "/auth/register",
+  "/auth/confirm",
+  "/auth/forgot-password",
+  "/auth/reset-password",
+];
+const SESSION_REDIRECT_AUTH_ROUTES = [
+  "/auth/login",
+  "/auth/register",
+  "/auth/confirm",
+  "/auth/forgot-password",
+];
+
 // Configure how notifications are displayed when the app is in the foreground
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
@@ -16,8 +30,6 @@ Notifications.setNotificationHandler({
     shouldSetBadge: false,
   }),
 });
-
-const AUTH_ROUTES = ["/auth/login", "/auth/register", "/auth/confirm"];
 
 function RootNavigator() {
   const { isLoading, session } = useAuth();
@@ -38,7 +50,7 @@ function RootNavigator() {
       return;
     }
 
-    if (session && AUTH_ROUTES.includes(pathname)) {
+    if (session && SESSION_REDIRECT_AUTH_ROUTES.includes(pathname)) {
       router.replace("/account" as Href);
       return;
     }

--- a/src/app/auth/forgot-password.tsx
+++ b/src/app/auth/forgot-password.tsx
@@ -1,4 +1,4 @@
-import { Link, type Href, useRouter } from "expo-router";
+import { Link, type Href } from "expo-router";
 import { useState } from "react";
 import {
   ActivityIndicator,
@@ -12,23 +12,30 @@ import {
 import { AuthScreenShell } from "../../components/auth-screen-shell";
 import { useAuth } from "../../providers/auth-provider";
 
-export default function LoginScreen() {
-  const router = useRouter();
-  const { signInWithPassword } = useAuth();
+export default function ForgotPasswordScreen() {
+  const { makePasswordResetRedirectUrl, requestPasswordReset } = useAuth();
   const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
-  const handleLogin = async () => {
+  const handleRequestReset = async () => {
     try {
       setLoading(true);
       setErrorMessage(null);
-      await signInWithPassword(email.trim(), password);
-      router.replace("/account" as Href);
+      setSuccessMessage(null);
+
+      const normalizedEmail = email.trim();
+
+      if (!normalizedEmail) {
+        throw new Error("Enter the email address for your account.");
+      }
+
+      await requestPasswordReset(normalizedEmail);
+      setSuccessMessage("Check your inbox for a password reset link.");
     } catch (error) {
       setErrorMessage(
-        error instanceof Error ? error.message : "Unable to sign in.",
+        error instanceof Error ? error.message : "Unable to send reset email.",
       );
     } finally {
       setLoading(false);
@@ -37,14 +44,14 @@ export default function LoginScreen() {
 
   return (
     <AuthScreenShell
-      eyebrow="Login"
-      title="Sign in to manage pickups and market days."
-      subtitle="Use your FarmConnect account to access reservations, pickup slots, and farmer-side planning tools."
+      eyebrow="Password reset"
+      title="Send a password reset link."
+      subtitle="Supabase will email a recovery link that opens FarmConnect so you can choose a new password."
       footer={
         <Text style={styles.footerText}>
-          Don&apos;t have an account yet?{" "}
-          <Link href={"/auth/register" as Href} style={styles.footerLink}>
-            Create one
+          Remembered it?{" "}
+          <Link href={"/auth/login" as Href} style={styles.footerLink}>
+            Back to login
           </Link>
         </Text>
       }
@@ -62,33 +69,27 @@ export default function LoginScreen() {
           value={email}
         />
       </View>
-      <View style={styles.fieldGroup}>
-        <Text style={styles.label}>Password</Text>
-        <TextInput
-          autoCapitalize="none"
-          onChangeText={setPassword}
-          placeholder="Password"
-          placeholderTextColor="#7A867D"
-          secureTextEntry
-          style={styles.input}
-          value={password}
-        />
-      </View>
-      <Link href={"/auth/forgot-password" as Href} style={styles.inlineLink}>
-        Forgot your password?
-      </Link>
       {errorMessage ? (
         <Text style={styles.errorText}>{errorMessage}</Text>
       ) : null}
+      {successMessage ? (
+        <View style={styles.infoCard}>
+          <Text style={styles.infoTitle}>Reset email sent</Text>
+          <Text style={styles.infoBody}>{successMessage}</Text>
+          <Text style={styles.infoMeta}>
+            Redirect target: {makePasswordResetRedirectUrl()}
+          </Text>
+        </View>
+      ) : null}
       <Pressable
         disabled={loading}
-        onPress={handleLogin}
+        onPress={handleRequestReset}
         style={[styles.primaryButton, loading && styles.buttonDisabled]}
       >
         {loading ? (
           <ActivityIndicator color="#FFFFFF" />
         ) : (
-          <Text style={styles.primaryButtonText}>Sign in</Text>
+          <Text style={styles.primaryButtonText}>Send reset link</Text>
         )}
       </Pressable>
     </AuthScreenShell>
@@ -135,11 +136,28 @@ const styles = StyleSheet.create({
     fontSize: 14,
     lineHeight: 20,
   },
-  inlineLink: {
-    alignSelf: "flex-start",
+  infoCard: {
+    backgroundColor: "#EEF5EB",
+    borderColor: "#DCE8D7",
+    borderRadius: 20,
+    borderWidth: 1,
+    gap: 6,
+    padding: 16,
+  },
+  infoTitle: {
     color: "#2F6A3E",
+    fontSize: 15,
+    fontWeight: "800",
+  },
+  infoBody: {
+    color: "#334338",
     fontSize: 14,
-    fontWeight: "700",
+    lineHeight: 20,
+  },
+  infoMeta: {
+    color: "#5D6A60",
+    fontSize: 12,
+    lineHeight: 18,
   },
   footerText: {
     color: "#5D6A60",

--- a/src/app/auth/reset-password.tsx
+++ b/src/app/auth/reset-password.tsx
@@ -1,0 +1,250 @@
+import { Link, type Href, useRouter } from "expo-router";
+import { useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+
+import { AuthScreenShell } from "../../components/auth-screen-shell";
+import { useAuth } from "../../providers/auth-provider";
+
+export default function ResetPasswordScreen() {
+  const router = useRouter();
+  const { session, updatePassword, user } = useAuth();
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const handleUpdatePassword = async () => {
+    try {
+      setLoading(true);
+      setErrorMessage(null);
+      setSuccessMessage(null);
+
+      if (!password || !confirmPassword) {
+        throw new Error("Enter and confirm your new password.");
+      }
+
+      if (password.length < 6) {
+        throw new Error("Password must be at least 6 characters.");
+      }
+
+      if (password !== confirmPassword) {
+        throw new Error("Passwords do not match.");
+      }
+
+      await updatePassword(password);
+      setPassword("");
+      setConfirmPassword("");
+      setSuccessMessage("Your password has been updated.");
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Unable to update password.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <AuthScreenShell
+      eyebrow="Password reset"
+      title={
+        session
+          ? "Choose a new password."
+          : "Open your reset link from your inbox."
+      }
+      subtitle={
+        session
+          ? "The recovery link verified your account. Set the new password before leaving this screen."
+          : "Request a reset email, then open the link on this device to continue."
+      }
+      footer={
+        <Text style={styles.footerText}>
+          Need a new link?{" "}
+          <Link
+            href={"/auth/forgot-password" as Href}
+            style={styles.footerLink}
+          >
+            Send another email
+          </Link>
+        </Text>
+      }
+    >
+      {user?.email ? (
+        <Text style={styles.metaText}>Resetting password for {user.email}</Text>
+      ) : null}
+      {session ? (
+        <>
+          <View style={styles.fieldGroup}>
+            <Text style={styles.label}>New password</Text>
+            <TextInput
+              autoCapitalize="none"
+              onChangeText={setPassword}
+              placeholder="New password"
+              placeholderTextColor="#7A867D"
+              secureTextEntry
+              style={styles.input}
+              value={password}
+            />
+          </View>
+          <View style={styles.fieldGroup}>
+            <Text style={styles.label}>Confirm new password</Text>
+            <TextInput
+              autoCapitalize="none"
+              onChangeText={setConfirmPassword}
+              placeholder="Repeat your new password"
+              placeholderTextColor="#7A867D"
+              secureTextEntry
+              style={styles.input}
+              value={confirmPassword}
+            />
+          </View>
+          {errorMessage ? (
+            <Text style={styles.errorText}>{errorMessage}</Text>
+          ) : null}
+          {successMessage ? (
+            <View style={styles.infoCard}>
+              <Text style={styles.infoTitle}>Password updated</Text>
+              <Text style={styles.infoBody}>{successMessage}</Text>
+            </View>
+          ) : null}
+          <Pressable
+            disabled={loading}
+            onPress={handleUpdatePassword}
+            style={[styles.primaryButton, loading && styles.buttonDisabled]}
+          >
+            {loading ? (
+              <ActivityIndicator color="#FFFFFF" />
+            ) : (
+              <Text style={styles.primaryButtonText}>Update password</Text>
+            )}
+          </Pressable>
+          {successMessage ? (
+            <Pressable
+              onPress={() => router.replace("/account" as Href)}
+              style={styles.secondaryButton}
+            >
+              <Text style={styles.secondaryButtonText}>
+                Continue to account
+              </Text>
+            </Pressable>
+          ) : null}
+        </>
+      ) : (
+        <>
+          <Text style={styles.messageText}>
+            This screen needs the temporary Supabase recovery session from your
+            reset email before it can change the password.
+          </Text>
+          <Pressable
+            onPress={() => router.replace("/auth/forgot-password" as Href)}
+            style={styles.primaryButton}
+          >
+            <Text style={styles.primaryButtonText}>Send reset link</Text>
+          </Pressable>
+        </>
+      )}
+    </AuthScreenShell>
+  );
+}
+
+const styles = StyleSheet.create({
+  fieldGroup: {
+    gap: 8,
+  },
+  label: {
+    color: "#182019",
+    fontSize: 14,
+    fontWeight: "700",
+  },
+  input: {
+    backgroundColor: "#FFFFFF",
+    borderColor: "#DDE4D9",
+    borderRadius: 18,
+    borderWidth: 1,
+    color: "#182019",
+    fontSize: 15,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+  },
+  primaryButton: {
+    alignItems: "center",
+    backgroundColor: "#2F6A3E",
+    borderRadius: 18,
+    justifyContent: "center",
+    minHeight: 52,
+    paddingHorizontal: 18,
+  },
+  primaryButtonText: {
+    color: "#FFFFFF",
+    fontSize: 15,
+    fontWeight: "700",
+  },
+  secondaryButton: {
+    alignItems: "center",
+    backgroundColor: "#EEF5EB",
+    borderColor: "#DCE8D7",
+    borderRadius: 18,
+    borderWidth: 1,
+    justifyContent: "center",
+    minHeight: 48,
+    paddingHorizontal: 18,
+  },
+  secondaryButtonText: {
+    color: "#2F6A3E",
+    fontSize: 15,
+    fontWeight: "700",
+  },
+  buttonDisabled: {
+    opacity: 0.7,
+  },
+  errorText: {
+    color: "#9C5B4D",
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  infoCard: {
+    backgroundColor: "#EEF5EB",
+    borderColor: "#DCE8D7",
+    borderRadius: 20,
+    borderWidth: 1,
+    gap: 6,
+    padding: 16,
+  },
+  infoTitle: {
+    color: "#2F6A3E",
+    fontSize: 15,
+    fontWeight: "800",
+  },
+  infoBody: {
+    color: "#334338",
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  messageText: {
+    color: "#5D6A60",
+    fontSize: 15,
+    lineHeight: 23,
+  },
+  metaText: {
+    color: "#2F6A3E",
+    fontSize: 13,
+    lineHeight: 20,
+  },
+  footerText: {
+    color: "#5D6A60",
+    fontSize: 14,
+    lineHeight: 22,
+  },
+  footerLink: {
+    color: "#2F6A3E",
+    fontWeight: "700",
+  },
+});

--- a/src/providers/auth-provider.tsx
+++ b/src/providers/auth-provider.tsx
@@ -60,10 +60,13 @@ type AuthContextValue = {
     password: string,
     details: SignUpProfileDetails,
   ) => Promise<SignUpResult>;
+  requestPasswordReset: (email: string) => Promise<void>;
+  updatePassword: (password: string) => Promise<void>;
   resendConfirmationEmail: (email: string) => Promise<void>;
   signOut: () => Promise<void>;
   clearAuthLinkState: () => void;
   makeEmailRedirectUrl: () => string;
+  makePasswordResetRedirectUrl: () => string;
   refreshProfile: () => Promise<void>;
   updateOwnProfile: (details: UpdateProfileDetails) => Promise<UserProfile>;
 };
@@ -71,6 +74,8 @@ type AuthContextValue = {
 const AuthContext = createContext<AuthContextValue | null>(null);
 
 const createRedirectUrl = () => Linking.createURL("/auth/confirm");
+const createPasswordResetRedirectUrl = () =>
+  Linking.createURL("/auth/reset-password");
 
 const parseUrlParams = (url: string) => {
   const parsedUrl = new URL(url);
@@ -181,7 +186,9 @@ export function AuthProvider({ children }: PropsWithChildren) {
           if (isMounted) {
             setAuthLinkStatus("success");
             setAuthLinkMessage(
-              "Email confirmed. Your session is now active on this device.",
+              params.type === "recovery"
+                ? "Password reset link verified. Choose a new password to finish recovering your account."
+                : "Email confirmed. Your session is now active on this device.",
             );
           }
           return;
@@ -206,9 +213,10 @@ export function AuthProvider({ children }: PropsWithChildren) {
         }
 
         if (params.token_hash) {
+          const linkType = normalizeEmailLinkType(params.type);
           const { error } = await supabaseClient.auth.verifyOtp({
             token_hash: params.token_hash,
-            type: normalizeEmailLinkType(params.type),
+            type: linkType,
           });
 
           if (error) {
@@ -218,7 +226,9 @@ export function AuthProvider({ children }: PropsWithChildren) {
           if (isMounted) {
             setAuthLinkStatus("success");
             setAuthLinkMessage(
-              "Email confirmed. Your account is ready to use.",
+              linkType === "recovery"
+                ? "Password reset link verified. Choose a new password to finish recovering your account."
+                : "Email confirmed. Your account is ready to use.",
             );
           }
           return;
@@ -355,6 +365,30 @@ export function AuthProvider({ children }: PropsWithChildren) {
           throw error;
         }
       },
+      async requestPasswordReset(email) {
+        if (!supabase) {
+          throw new Error("Supabase is not configured.");
+        }
+
+        const { error } = await supabase.auth.resetPasswordForEmail(email, {
+          redirectTo: createPasswordResetRedirectUrl(),
+        });
+
+        if (error) {
+          throw error;
+        }
+      },
+      async updatePassword(password) {
+        if (!supabase) {
+          throw new Error("Supabase is not configured.");
+        }
+
+        const { error } = await supabase.auth.updateUser({ password });
+
+        if (error) {
+          throw error;
+        }
+      },
       async signOut() {
         if (!supabase) {
           throw new Error("Supabase is not configured.");
@@ -372,6 +406,9 @@ export function AuthProvider({ children }: PropsWithChildren) {
       },
       makeEmailRedirectUrl() {
         return createRedirectUrl();
+      },
+      makePasswordResetRedirectUrl() {
+        return createPasswordResetRedirectUrl();
       },
       async refreshProfile() {
         await syncProfile(session?.user ?? null);

--- a/tests/auth-screens.test.tsx
+++ b/tests/auth-screens.test.tsx
@@ -1,13 +1,17 @@
 import { render, screen } from "@testing-library/react-native";
 
 import ConfirmEmailScreen from "../src/app/auth/confirm";
+import ForgotPasswordScreen from "../src/app/auth/forgot-password";
 import LoginScreen from "../src/app/auth/login";
 import RegisterScreen from "../src/app/auth/register";
+import ResetPasswordScreen from "../src/app/auth/reset-password";
+
+let mockSession: { user: { email: string } } | null = null;
 
 jest.mock("../src/providers/auth-provider", () => ({
   useAuth: () => ({
-    session: null,
-    user: null,
+    session: mockSession,
+    user: mockSession?.user ?? null,
     profile: null,
     profileLoading: false,
     profileError: null,
@@ -16,15 +20,22 @@ jest.mock("../src/providers/auth-provider", () => ({
     authLinkMessage: null,
     signInWithPassword: jest.fn(),
     signUpWithPassword: jest.fn(),
+    requestPasswordReset: jest.fn(),
+    updatePassword: jest.fn(),
     resendConfirmationEmail: jest.fn(),
     signOut: jest.fn(),
     clearAuthLinkState: jest.fn(),
     makeEmailRedirectUrl: () => "farmconnect://auth/confirm",
+    makePasswordResetRedirectUrl: () => "farmconnect://auth/reset-password",
     refreshProfile: jest.fn(),
   }),
 }));
 
 describe("Auth screens", () => {
+  beforeEach(() => {
+    mockSession = null;
+  });
+
   it("renders the login page", () => {
     render(<LoginScreen />);
 
@@ -32,6 +43,7 @@ describe("Auth screens", () => {
       screen.getByText("Sign in to manage pickups and market days."),
     ).toBeTruthy();
     expect(screen.getByPlaceholderText("you@farmconnect.app")).toBeTruthy();
+    expect(screen.getByText("Forgot your password?")).toBeTruthy();
     expect(screen.getByText("Sign in")).toBeTruthy();
   });
 
@@ -56,5 +68,35 @@ describe("Auth screens", () => {
       screen.getByText("Open the confirmation link from your inbox."),
     ).toBeTruthy();
     expect(screen.getByText("Back to login")).toBeTruthy();
+  });
+
+  it("renders the forgot password page", () => {
+    render(<ForgotPasswordScreen />);
+
+    expect(screen.getByText("Send a password reset link.")).toBeTruthy();
+    expect(screen.getByPlaceholderText("you@farmconnect.app")).toBeTruthy();
+    expect(screen.getByText("Send reset link")).toBeTruthy();
+  });
+
+  it("renders the reset password page for a recovery session", () => {
+    mockSession = { user: { email: "you@farmconnect.app" } };
+
+    render(<ResetPasswordScreen />);
+
+    expect(screen.getByText("Choose a new password.")).toBeTruthy();
+    expect(
+      screen.getByText("Resetting password for you@farmconnect.app"),
+    ).toBeTruthy();
+    expect(screen.getByPlaceholderText("New password")).toBeTruthy();
+    expect(screen.getByText("Update password")).toBeTruthy();
+  });
+
+  it("renders reset guidance without a recovery session", () => {
+    render(<ResetPasswordScreen />);
+
+    expect(
+      screen.getByText("Open your reset link from your inbox."),
+    ).toBeTruthy();
+    expect(screen.getAllByText("Send reset link")).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Closes #89.

Adds a Supabase-backed forgot password flow from login through password update after a recovery deep link.

Notes:
- Supabase Auth needs `farmconnect://auth/reset-password` in the redirect allow list.
- No database migration is needed; this uses Supabase Auth reset/update APIs.

Validation:
- `npm run typecheck`
- `EXPO_NO_TELEMETRY=1 npm run lint`
- `npm test -- --runInBand`
- `npm run format:check`