### PR TITLE
feat: farm-specific inventory management and order attribution

### DIFF
--- a/src/app/checkout/index.tsx
+++ b/src/app/checkout/index.tsx
@@ -71,6 +71,7 @@ export default function Checkout() {
 
   useEffect(() => {
     if (!paymentSuccess) return;
+    if (!session?.user.id) return;
 
     const items = cartItemsRef.current.map((item) => ({
       produce_id: item.produce_id,
@@ -81,7 +82,7 @@ export default function Checkout() {
     }));
 
     createOrder({
-      customer_id: session!.user.id,
+      customer_id: session.user.id,
       farm_id: farmIdRef.current,
       delivery_method: deliveryRef.current,
       pickup_notes: pickupNotesRef.current,

--- a/src/app/checkout/index.tsx
+++ b/src/app/checkout/index.tsx
@@ -18,16 +18,17 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-// TODO: replace with real farm_id from farm inventory when per-farm produce is implemented
-const MOCK_FARM_ID = "005eb263-c5d6-42fc-bae5-47847b952c1a";
-
 type DeliveryMethod = "pickup" | "reservation";
 
 export default function Checkout() {
-  const farm_id = MOCK_FARM_ID;
   const { session } = useAuth();
   const router = useRouter();
   const { cartItems, clearCart, removeItem } = useCart();
+  const farm_id = cartItems[0]?.farm_id ?? "";
+  const farmIdRef = useRef(farm_id);
+  useEffect(() => {
+    farmIdRef.current = farm_id;
+  }, [farm_id]);
 
   const [delivery, setDelivery] = useState<DeliveryMethod>("pickup");
   const deliveryRef = useRef(delivery);
@@ -72,6 +73,7 @@ export default function Checkout() {
     if (!paymentSuccess) return;
 
     const items = cartItemsRef.current.map((item) => ({
+      produce_id: item.produce_id,
       produce_name: item.produce_name,
       qty: item.qty,
       unit: item.unit,
@@ -80,7 +82,7 @@ export default function Checkout() {
 
     createOrder({
       customer_id: session!.user.id,
-      farm_id,
+      farm_id: farmIdRef.current,
       delivery_method: deliveryRef.current,
       pickup_notes: pickupNotesRef.current,
       items,
@@ -104,7 +106,7 @@ export default function Checkout() {
           "Payment succeeded but order could not be saved. Please contact support.",
         ),
       );
-  }, [paymentSuccess, session, farm_id, router, clearCart]);
+  }, [paymentSuccess, session, router, clearCart]);
 
   async function handleReserve() {
     if (!session?.user.id) {
@@ -113,6 +115,7 @@ export default function Checkout() {
     }
 
     const items = cartItems.map((item) => ({
+      produce_id: item.produce_id,
       produce_name: item.produce_name,
       qty: item.qty,
       unit: item.unit,

--- a/src/app/farm/[farmId].tsx
+++ b/src/app/farm/[farmId].tsx
@@ -10,6 +10,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { FarmHeroCard } from "../../components/FarmHeroCard";
+import { fetchProduceByFarm, type FarmProduce } from "../../lib/farmProduce";
 import {
   deleteFarmProfile,
   type FarmPickupDetails,
@@ -285,6 +286,7 @@ export default function FarmProfileScreen() {
   const [marketDaysError, setMarketDaysError] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [farmProduce, setFarmProduce] = useState<FarmProduce[]>([]);
 
   useEffect(() => {
     let cancelled = false;
@@ -342,6 +344,11 @@ export default function FarmProfileScreen() {
     return () => {
       cancelled = true;
     };
+  }, [farmId]);
+
+  useEffect(() => {
+    if (!farmId) return;
+    fetchProduceByFarm(farmId).then(setFarmProduce);
   }, [farmId]);
 
   const handleDelete = () => {
@@ -417,6 +424,40 @@ export default function FarmProfileScreen() {
           onEdit={() => router.replace("/farm/edit")}
           onDelete={handleDelete}
         />
+        {isOwner ? (
+          <Pressable
+            onPress={() => router.push("/farm/stock")}
+            style={farmStyles.inlineButton}
+          >
+            <Text style={farmStyles.inlineButtonText}>Manage Stock</Text>
+          </Pressable>
+        ) : null}
+        {farmProduce.length > 0 ? (
+          <View style={farmStyles.panel}>
+            <Text style={farmStyles.panelTitle}>Products</Text>
+            {farmProduce.map((item) => (
+              <Pressable
+                key={item.id}
+                style={farmStyles.inlineButton}
+                onPress={() =>
+                  router.push({
+                    pathname: "/produce/[produce]",
+                    params: {
+                      produce: item.produce_id,
+                      farmId: farmProfile.user_id,
+                      price: item.price,
+                      unit: item.unit,
+                    },
+                  })
+                }
+              >
+                <Text style={farmStyles.inlineButtonText}>
+                  {item.name_nb} — {item.price} kr / {item.unit}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        ) : null}
       </ScrollView>
     </SafeAreaView>
   );

--- a/src/app/farm/[farmId].tsx
+++ b/src/app/farm/[farmId].tsx
@@ -447,6 +447,7 @@ export default function FarmProfileScreen() {
                       farmId: farmProfile.user_id,
                       price: item.price,
                       unit: item.unit,
+                      stock: item.stock,
                     },
                   })
                 }

--- a/src/app/farm/stock.tsx
+++ b/src/app/farm/stock.tsx
@@ -1,0 +1,354 @@
+import {
+  deleteFarmProduce,
+  fetchProduceByFarm,
+  upsertFarmProduce,
+  type FarmProduce,
+} from "@/lib/farmProduce";
+import { fetchFarmProfileByUserId } from "@/lib/farmProfiles";
+import { useAuth } from "@/providers/auth-provider";
+import { farmStyles } from "@/styles/farm-styles";
+import { useRouter } from "expo-router";
+import { useEffect, useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  Modal,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import produceData from "../../data/produceData.json";
+
+type ProduceDataItem = {
+  id: string;
+  name_nb: string;
+  unit: string;
+  price: number;
+};
+
+type ProduceDataFile = { items: ProduceDataItem[] };
+
+const typedProduceData = produceData as ProduceDataFile;
+
+type EditModal = {
+  produceId: string;
+  name: string;
+  price: string;
+  stock: string;
+  unit: string;
+};
+
+export default function FarmStockScreen() {
+  const { user } = useAuth();
+  const router = useRouter();
+
+  const [farmId, setFarmId] = useState<string | null>(null);
+  const [stockItems, setStockItems] = useState<FarmProduce[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [modal, setModal] = useState<EditModal | null>(null);
+
+  useEffect(() => {
+    if (!user) return;
+    fetchFarmProfileByUserId(user.id)
+      .then((profile) => {
+        if (!profile) return;
+        setFarmId(profile.id);
+        return fetchProduceByFarm(profile.id);
+      })
+      .then((items) => setStockItems(items ?? []))
+      .catch((e) => Alert.alert("Error", e.message))
+      .finally(() => setLoading(false));
+  }, [user]);
+
+  async function refreshStock() {
+    if (!farmId) return;
+    const items = await fetchProduceByFarm(farmId);
+    setStockItems(items);
+  }
+
+  function openAdd(item: ProduceDataItem) {
+    setModal({
+      produceId: item.id,
+      name: item.name_nb,
+      price: String(item.price),
+      stock: "0",
+      unit: item.unit,
+    });
+  }
+
+  function openEdit(item: FarmProduce) {
+    setModal({
+      produceId: item.produce_id,
+      name: item.name_nb ?? item.produce_id,
+      price: String(item.price),
+      stock: String(item.stock),
+      unit: item.unit,
+    });
+  }
+
+  async function handleSave() {
+    if (!modal || !farmId) return;
+    const price = parseFloat(modal.price);
+    const stock = parseFloat(modal.stock);
+    if (isNaN(price) || price < 0) {
+      Alert.alert("Invalid price", "Enter a valid price.");
+      return;
+    }
+    if (isNaN(stock) || stock < 0) {
+      Alert.alert("Invalid stock", "Enter a valid stock amount.");
+      return;
+    }
+    setSaving(true);
+    try {
+      await upsertFarmProduce(
+        farmId,
+        modal.produceId,
+        price,
+        stock,
+        modal.unit,
+      );
+      await refreshStock();
+      setModal(null);
+    } catch (e: unknown) {
+      Alert.alert("Error", e instanceof Error ? e.message : "Could not save.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleDelete(item: FarmProduce) {
+    Alert.alert(
+      "Remove product",
+      `Remove ${item.name_nb ?? item.produce_id} from your stock?`,
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Remove",
+          style: "destructive",
+          onPress: async () => {
+            if (!farmId) return;
+            try {
+              await deleteFarmProduce(farmId, item.produce_id);
+              await refreshStock();
+            } catch (e: unknown) {
+              Alert.alert(
+                "Error",
+                e instanceof Error ? e.message : "Could not delete.",
+              );
+            }
+          },
+        },
+      ],
+    );
+  }
+
+  const stockIds = new Set(stockItems.map((i) => i.produce_id));
+
+  const availableToAdd = typedProduceData.items.filter(
+    (i) =>
+      !stockIds.has(i.id) &&
+      i.name_nb.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  if (loading) {
+    return (
+      <SafeAreaView style={farmStyles.page}>
+        <ActivityIndicator color="#2F6A3E" />
+      </SafeAreaView>
+    );
+  }
+
+  if (!farmId) {
+    return (
+      <SafeAreaView style={farmStyles.page}>
+        <Text style={farmStyles.errorText}>
+          You don&apos;t have a farm profile yet.
+        </Text>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={farmStyles.page}>
+      <ScrollView
+        contentContainerStyle={farmStyles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={farmStyles.panel}>
+          <View
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
+            <Text style={farmStyles.panelTitle}>My Stock</Text>
+            <Pressable
+              onPress={() => router.back()}
+              style={farmStyles.inlineButton}
+            >
+              <Text style={farmStyles.inlineButtonText}>← Back</Text>
+            </Pressable>
+          </View>
+
+          {stockItems.length === 0 ? (
+            <Text style={farmStyles.emptyText}>No products in stock yet.</Text>
+          ) : (
+            stockItems.map((item) => (
+              <View key={item.id} style={farmStyles.readonlyItem}>
+                <View
+                  style={{
+                    flexDirection: "row",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                  }}
+                >
+                  <View style={{ flex: 1, gap: 2 }}>
+                    <Text style={farmStyles.rowName}>
+                      {item.name_nb ?? item.produce_id}
+                    </Text>
+                    <Text style={farmStyles.readonlyMeta}>
+                      {item.price} kr / {item.unit} · Stock: {item.stock}
+                    </Text>
+                  </View>
+                  <View style={{ flexDirection: "row", gap: 8 }}>
+                    <Pressable
+                      onPress={() => openEdit(item)}
+                      style={farmStyles.inlineButton}
+                    >
+                      <Text style={farmStyles.inlineButtonText}>Edit</Text>
+                    </Pressable>
+                    <Pressable
+                      onPress={() => handleDelete(item)}
+                      style={[
+                        farmStyles.inlineButton,
+                        { backgroundColor: "#F9EDEB" },
+                      ]}
+                    >
+                      <Text
+                        style={[
+                          farmStyles.inlineButtonText,
+                          { color: "#7A2A20" },
+                        ]}
+                      >
+                        Remove
+                      </Text>
+                    </Pressable>
+                  </View>
+                </View>
+              </View>
+            ))
+          )}
+        </View>
+
+        <View style={farmStyles.panel}>
+          <Text style={farmStyles.panelTitle}>Add Products</Text>
+          <TextInput
+            style={farmStyles.searchInput}
+            placeholder="Search produce..."
+            placeholderTextColor="#9AA89D"
+            value={search}
+            onChangeText={setSearch}
+          />
+          {availableToAdd.length === 0 ? (
+            <Text style={farmStyles.emptyText}>No products to add.</Text>
+          ) : (
+            availableToAdd.map((item) => (
+              <View key={item.id} style={farmStyles.readonlyItem}>
+                <View
+                  style={{
+                    flexDirection: "row",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                  }}
+                >
+                  <View style={{ gap: 2 }}>
+                    <Text style={farmStyles.rowName}>{item.name_nb}</Text>
+                    <Text style={farmStyles.readonlyMeta}>
+                      {item.price} kr / {item.unit}
+                    </Text>
+                  </View>
+                  <Pressable
+                    onPress={() => openAdd(item)}
+                    style={farmStyles.inlineButton}
+                  >
+                    <Text style={farmStyles.inlineButtonText}>+ Add</Text>
+                  </Pressable>
+                </View>
+              </View>
+            ))
+          )}
+        </View>
+      </ScrollView>
+
+      <Modal visible={modal !== null} transparent animationType="fade">
+        <View
+          style={{
+            flex: 1,
+            backgroundColor: "rgba(0,0,0,0.4)",
+            justifyContent: "center",
+            padding: 24,
+          }}
+        >
+          <View style={farmStyles.card}>
+            <Text style={farmStyles.panelTitle}>
+              {stockIds.has(modal?.produceId ?? "") ? "Edit" : "Add"}{" "}
+              {modal?.name}
+            </Text>
+
+            <View style={farmStyles.fieldGroup}>
+              <Text style={farmStyles.label}>Price (kr)</Text>
+              <TextInput
+                style={farmStyles.input}
+                keyboardType="decimal-pad"
+                value={modal?.price ?? ""}
+                onChangeText={(v) =>
+                  setModal((m) => (m ? { ...m, price: v } : m))
+                }
+              />
+            </View>
+
+            <View style={farmStyles.fieldGroup}>
+              <Text style={farmStyles.label}>Stock ({modal?.unit})</Text>
+              <TextInput
+                style={farmStyles.input}
+                keyboardType="decimal-pad"
+                value={modal?.stock ?? ""}
+                onChangeText={(v) =>
+                  setModal((m) => (m ? { ...m, stock: v } : m))
+                }
+              />
+            </View>
+
+            <Pressable
+              style={[
+                farmStyles.primaryButton,
+                saving && farmStyles.buttonDisabled,
+              ]}
+              onPress={handleSave}
+              disabled={saving}
+            >
+              {saving ? (
+                <ActivityIndicator color="#fff" />
+              ) : (
+                <Text style={farmStyles.primaryButtonText}>Save</Text>
+              )}
+            </Pressable>
+
+            <Pressable
+              style={[farmStyles.inlineButton, { alignSelf: "center" }]}
+              onPress={() => setModal(null)}
+            >
+              <Text style={farmStyles.inlineButtonText}>Cancel</Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
+    </SafeAreaView>
+  );
+}

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -96,7 +96,7 @@ export default function Index() {
                 {typedProduceData.items.slice(0, 8).map((item) => (
                   <ScaleButton
                     key={item.id}
-                    onPress={() => router.push(`/produce/${item.id}` as Href)}
+                    onPress={() => router.push("/produce" as Href)}
                     style={homeStyles.produceChip}
                     textStyle={homeStyles.produceChipText}
                   >

--- a/src/app/produce/[produce].tsx
+++ b/src/app/produce/[produce].tsx
@@ -1,7 +1,7 @@
 import { useCart } from "@/providers/cart-provider";
 import { produceStyles } from "@/styles/produce-styles";
 import * as Linking from "expo-linking";
-import { useLocalSearchParams, useRouter } from "expo-router";
+import { type Href, useLocalSearchParams, useRouter } from "expo-router";
 import { useState } from "react";
 import { Pressable, ScrollView, Text, View } from "react-native";
 import produceData from "../../data/produceData.json";
@@ -164,33 +164,44 @@ export default function ProduceScreen() {
           ))}
         </View>
 
-        <View style={produceStyles.cartSection}>
-          <View style={produceStyles.qtyRow}>
+        {farmId ? (
+          <View style={produceStyles.cartSection}>
+            <View style={produceStyles.qtyRow}>
+              <Pressable
+                style={produceStyles.qtyButton}
+                onPress={() => setQty((q) => Math.max(1, q - 1))}
+              >
+                <Text style={produceStyles.qtyButtonText}>−</Text>
+              </Pressable>
+              <Text style={produceStyles.qtyValue}>
+                {qty} {farmUnit}
+              </Text>
+              <Pressable
+                style={produceStyles.qtyButton}
+                onPress={() => setQty((q) => q + 1)}
+              >
+                <Text style={produceStyles.qtyButtonText}>+</Text>
+              </Pressable>
+            </View>
             <Pressable
-              style={produceStyles.qtyButton}
-              onPress={() => setQty((q) => Math.max(1, q - 1))}
+              style={produceStyles.addToCartButton}
+              onPress={handleAddToCart}
             >
-              <Text style={produceStyles.qtyButtonText}>−</Text>
-            </Pressable>
-            <Text style={produceStyles.qtyValue}>
-              {qty} {farmUnit}
-            </Text>
-            <Pressable
-              style={produceStyles.qtyButton}
-              onPress={() => setQty((q) => q + 1)}
-            >
-              <Text style={produceStyles.qtyButtonText}>+</Text>
+              <Text style={produceStyles.addToCartText}>
+                Add to Cart · {farmPrice * qty} kr
+              </Text>
             </Pressable>
           </View>
+        ) : (
           <Pressable
             style={produceStyles.addToCartButton}
-            onPress={handleAddToCart}
+            onPress={() => router.push("/produce" as Href)}
           >
             <Text style={produceStyles.addToCartText}>
-              Add to Cart · {farmPrice * qty} kr
+              Browse farms to purchase
             </Text>
           </Pressable>
-        </View>
+        )}
       </View>
     </ScrollView>
   );

--- a/src/app/produce/[produce].tsx
+++ b/src/app/produce/[produce].tsx
@@ -74,12 +74,19 @@ function NutritionRow({ label, value }: { label: string; value: string }) {
 }
 
 export default function ProduceScreen() {
-  const { produce } = useLocalSearchParams<{ produce: string }>();
+  const { produce, farmId, price, unit } = useLocalSearchParams<{
+    produce: string;
+    farmId: string;
+    price: string;
+    unit: string;
+  }>();
   const router = useRouter();
   const { addItem } = useCart();
   const [qty, setQty] = useState(1);
 
   const item = typedProduceData.items.find((i) => i.id === produce);
+  const farmPrice = price ? parseFloat(price) : (item?.price ?? 0);
+  const farmUnit = unit ?? item?.unit ?? "";
 
   if (!item) {
     return (
@@ -95,9 +102,10 @@ export default function ProduceScreen() {
     addItem({
       produce_id: item!.id,
       produce_name: item!.name_nb,
+      farm_id: farmId,
       qty,
-      unit: item!.unit,
-      price_per_unit: item!.price,
+      unit: farmUnit,
+      price_per_unit: farmPrice,
     });
     router.push("/(tabs)/checkout");
   }
@@ -165,7 +173,7 @@ export default function ProduceScreen() {
               <Text style={produceStyles.qtyButtonText}>−</Text>
             </Pressable>
             <Text style={produceStyles.qtyValue}>
-              {qty} {item.unit}
+              {qty} {farmUnit}
             </Text>
             <Pressable
               style={produceStyles.qtyButton}
@@ -179,7 +187,7 @@ export default function ProduceScreen() {
             onPress={handleAddToCart}
           >
             <Text style={produceStyles.addToCartText}>
-              Add to Cart · {item.price * qty} kr
+              Add to Cart · {farmPrice * qty} kr
             </Text>
           </Pressable>
         </View>

--- a/src/app/produce/[produce].tsx
+++ b/src/app/produce/[produce].tsx
@@ -74,11 +74,12 @@ function NutritionRow({ label, value }: { label: string; value: string }) {
 }
 
 export default function ProduceScreen() {
-  const { produce, farmId, price, unit } = useLocalSearchParams<{
+  const { produce, farmId, price, unit, stock } = useLocalSearchParams<{
     produce: string;
     farmId: string;
     price: string;
     unit: string;
+    stock: string;
   }>();
   const router = useRouter();
   const { addItem } = useCart();
@@ -87,6 +88,7 @@ export default function ProduceScreen() {
   const item = typedProduceData.items.find((i) => i.id === produce);
   const farmPrice = price ? parseFloat(price) : (item?.price ?? 0);
   const farmUnit = unit ?? item?.unit ?? "";
+  const availableStock = stock ? parseFloat(stock) : null;
 
   if (!item) {
     return (
@@ -166,6 +168,11 @@ export default function ProduceScreen() {
 
         {farmId ? (
           <View style={produceStyles.cartSection}>
+            {availableStock !== null ? (
+              <Text style={produceStyles.detail}>
+                {availableStock} {farmUnit} available
+              </Text>
+            ) : null}
             <View style={produceStyles.qtyRow}>
               <Pressable
                 style={produceStyles.qtyButton}
@@ -178,7 +185,13 @@ export default function ProduceScreen() {
               </Text>
               <Pressable
                 style={produceStyles.qtyButton}
-                onPress={() => setQty((q) => q + 1)}
+                onPress={() =>
+                  setQty((q) =>
+                    availableStock !== null
+                      ? Math.min(availableStock, q + 1)
+                      : q + 1,
+                  )
+                }
               >
                 <Text style={produceStyles.qtyButtonText}>+</Text>
               </Pressable>

--- a/src/app/produce/index.tsx
+++ b/src/app/produce/index.tsx
@@ -1,43 +1,138 @@
+import { fetchAllFarmProfiles, type FarmProfile } from "@/lib/farmProfiles";
 import { produceStyles } from "@/styles/produce-styles";
 import { useRouter } from "expo-router";
-import { Pressable, ScrollView, Text, View } from "react-native";
-import produceData from "../../data/produceData.json";
+import { useEffect, useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
-type ProductDataItem = {
-  id: string;
-  name_nb: string;
-  name_en: string | null;
-};
-
-type ProduceDataFile = {
-  items: ProductDataItem[];
-};
-
-const typedProduceData = produceData as ProduceDataFile;
-
-export default function ProduceListScreen() {
+export default function FarmListScreen() {
   const router = useRouter();
+  const [farms, setFarms] = useState<FarmProfile[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    fetchAllFarmProfiles()
+      .then(setFarms)
+      .finally(() => setLoading(false));
+  }, []);
+
+  const filtered = farms.filter(
+    (f) =>
+      f.farm_name.toLowerCase().includes(search.toLowerCase()) ||
+      (f.city ?? "").toLowerCase().includes(search.toLowerCase()),
+  );
+
+  if (loading) {
+    return (
+      <SafeAreaView style={produceStyles.container}>
+        <ActivityIndicator color="#2F6A3E" />
+      </SafeAreaView>
+    );
+  }
 
   return (
-    <View style={produceStyles.container}>
-      <View style={produceStyles.card}>
-        <Text style={produceStyles.title}>Produce List</Text>
+    <SafeAreaView style={produceStyles.container}>
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ gap: 16, paddingBottom: 32 }}
+      >
+        {/* Header */}
+        <View style={{ gap: 4 }}>
+          <Text
+            style={{
+              color: "#2F6A3E",
+              fontSize: 11,
+              fontWeight: "800",
+              letterSpacing: 1,
+              textTransform: "uppercase",
+            }}
+          >
+            FARMS
+          </Text>
+          <Text style={produceStyles.title}>Browse registered farms</Text>
+        </View>
 
-        <ScrollView
-          showsVerticalScrollIndicator={false}
-          contentContainerStyle={produceStyles.listContent}
-        >
-          {typedProduceData.items.map((item) => (
+        {/* Search */}
+        <TextInput
+          style={{
+            backgroundColor: "#FFFFFF",
+            borderColor: "#DDE4D9",
+            borderRadius: 18,
+            borderWidth: 1,
+            color: "#182019",
+            fontSize: 15,
+            paddingHorizontal: 16,
+            paddingVertical: 13,
+          }}
+          placeholder="Search by name or location"
+          placeholderTextColor="#9AA89D"
+          value={search}
+          onChangeText={setSearch}
+        />
+
+        {/* Farm cards */}
+        {filtered.length === 0 ? (
+          <Text style={produceStyles.detail}>No farms found.</Text>
+        ) : (
+          filtered.map((farm) => (
             <Pressable
-              key={item.id}
-              onPress={() => router.push(`/produce/${item.id}`)}
-              style={produceStyles.produceItem}
+              key={farm.id}
+              onPress={() => router.push(`/farm/${farm.id}`)}
+              style={{
+                backgroundColor: "#FFFFFF",
+                borderColor: "#DDE4D9",
+                borderRadius: 24,
+                borderWidth: 1,
+                padding: 18,
+                gap: 6,
+                boxShadow: "0px 18px 30px rgba(24, 32, 25, 0.08)",
+              }}
             >
-              <Text style={produceStyles.produceName}>{item.name_nb}</Text>
+              <View
+                style={{ flexDirection: "row", alignItems: "center", gap: 12 }}
+              >
+                <View
+                  style={{
+                    backgroundColor: "#EEF5EB",
+                    borderRadius: 999,
+                    width: 44,
+                    height: 44,
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  <Text
+                    style={{
+                      color: "#2F6A3E",
+                      fontSize: 16,
+                      fontWeight: "800",
+                    }}
+                  >
+                    {farm.farm_name.charAt(0).toUpperCase()}
+                  </Text>
+                </View>
+                <View style={{ flex: 1, gap: 2 }}>
+                  <Text style={produceStyles.produceName}>
+                    {farm.farm_name}
+                  </Text>
+                  {farm.city ? (
+                    <Text style={produceStyles.detail}>{farm.city}</Text>
+                  ) : null}
+                </View>
+                <Text style={{ color: "#9AA89D", fontSize: 18 }}>›</Text>
+              </View>
             </Pressable>
-          ))}
-        </ScrollView>
-      </View>
-    </View>
+          ))
+        )}
+      </ScrollView>
+    </SafeAreaView>
   );
 }

--- a/src/lib/checkout/order.ts
+++ b/src/lib/checkout/order.ts
@@ -70,37 +70,17 @@ export async function createOrder(input: CreateOrderInput): Promise<Order> {
 
   if (itemsError) throw itemsError;
 
-  // Decrement stock in farm_produce. farm_produce.farm_id references farm_profiles(id),
-  // while input.farm_id is profiles(id) = farm_profiles.user_id, so we resolve it first.
   const itemsWithProduce = input.items.filter((i) => i.produce_id);
   if (itemsWithProduce.length > 0) {
-    const { data: farmProfileData } = await supabase
-      .from("farm_profiles")
-      .select("id")
-      .eq("user_id", input.farm_id)
-      .single();
-
-    if (farmProfileData) {
-      for (const item of itemsWithProduce) {
-        const { data: stockRow } = await supabase
-          .from("farm_produce")
-          .select("stock")
-          .eq("farm_id", farmProfileData.id)
-          .eq("produce_id", item.produce_id!)
-          .single();
-
-        if (stockRow && stockRow.stock >= item.qty) {
-          await supabase
-            .from("farm_produce")
-            .update({
-              stock: stockRow.stock - item.qty,
-              updated_at: new Date().toISOString(),
-            })
-            .eq("farm_id", farmProfileData.id)
-            .eq("produce_id", item.produce_id!);
-        }
-      }
-    }
+    await supabase.functions.invoke("decrement-stock", {
+      body: {
+        farm_user_id: input.farm_id,
+        items: itemsWithProduce.map((i) => ({
+          produce_id: i.produce_id,
+          qty: i.qty,
+        })),
+      },
+    });
   }
 
   return order;

--- a/src/lib/checkout/order.ts
+++ b/src/lib/checkout/order.ts
@@ -30,7 +30,7 @@ export type CreateOrderInput = {
   farm_id: string;
   delivery_method: DeliveryMethod;
   pickup_notes?: string;
-  items: Omit<OrderItem, "id" | "order_id">[];
+  items: (Omit<OrderItem, "id" | "order_id"> & { produce_id?: string })[];
 };
 
 export async function createOrder(input: CreateOrderInput): Promise<Order> {
@@ -69,6 +69,39 @@ export async function createOrder(input: CreateOrderInput): Promise<Order> {
   );
 
   if (itemsError) throw itemsError;
+
+  // Decrement stock in farm_produce. farm_produce.farm_id references farm_profiles(id),
+  // while input.farm_id is profiles(id) = farm_profiles.user_id, so we resolve it first.
+  const itemsWithProduce = input.items.filter((i) => i.produce_id);
+  if (itemsWithProduce.length > 0) {
+    const { data: farmProfileData } = await supabase
+      .from("farm_profiles")
+      .select("id")
+      .eq("user_id", input.farm_id)
+      .single();
+
+    if (farmProfileData) {
+      for (const item of itemsWithProduce) {
+        const { data: stockRow } = await supabase
+          .from("farm_produce")
+          .select("stock")
+          .eq("farm_id", farmProfileData.id)
+          .eq("produce_id", item.produce_id!)
+          .single();
+
+        if (stockRow && stockRow.stock >= item.qty) {
+          await supabase
+            .from("farm_produce")
+            .update({
+              stock: stockRow.stock - item.qty,
+              updated_at: new Date().toISOString(),
+            })
+            .eq("farm_id", farmProfileData.id)
+            .eq("produce_id", item.produce_id!);
+        }
+      }
+    }
+  }
 
   return order;
 }

--- a/src/lib/farmProduce.ts
+++ b/src/lib/farmProduce.ts
@@ -30,7 +30,8 @@ export async function fetchProduceByFarm(
     .from("farm_produce")
     .select("*")
     .eq("farm_id", farmId)
-    .eq("is_available", true);
+    .eq("is_available", true)
+    .gt("stock", 0);
 
   if (error) throw error;
 

--- a/src/lib/farmProduce.ts
+++ b/src/lib/farmProduce.ts
@@ -1,0 +1,105 @@
+import produceData from "../data/produceData.json";
+import { supabase } from "./supabase";
+
+type ProduceDataFile = {
+  items: { id: string; name_nb: string; unit: string; price: number }[];
+};
+
+const typedProduceData = produceData as ProduceDataFile;
+
+export type FarmProduce = {
+  id: string;
+  farm_id: string;
+  produce_id: string;
+  price: number;
+  stock: number;
+  unit: string;
+  is_available: boolean;
+  created_at: string;
+  updated_at: string;
+  // Joined from produceData.json locally
+  name_nb?: string;
+};
+
+export async function fetchProduceByFarm(
+  farmId: string,
+): Promise<FarmProduce[]> {
+  if (!supabase) throw new Error("Supabase is not configured.");
+
+  const { data, error } = await supabase
+    .from("farm_produce")
+    .select("*")
+    .eq("farm_id", farmId)
+    .eq("is_available", true);
+
+  if (error) throw error;
+
+  // Join med lokal produceData for å få navn
+  return (data ?? []).map((row) => {
+    const match = typedProduceData.items.find((i) => i.id === row.produce_id);
+    return { ...row, name_nb: match?.name_nb ?? row.produce_id };
+  });
+}
+
+export async function upsertFarmProduce(
+  farmId: string,
+  produceId: string,
+  price: number,
+  stock: number,
+  unit: string,
+): Promise<void> {
+  if (!supabase) throw new Error("Supabase is not configured.");
+
+  const { error } = await supabase.from("farm_produce").upsert(
+    {
+      farm_id: farmId,
+      produce_id: produceId,
+      price,
+      stock,
+      unit,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "farm_id,produce_id" },
+  );
+
+  if (error) throw error;
+}
+
+export async function deleteFarmProduce(
+  farmId: string,
+  produceId: string,
+): Promise<void> {
+  if (!supabase) throw new Error("Supabase is not configured.");
+
+  const { error } = await supabase
+    .from("farm_produce")
+    .delete()
+    .eq("farm_id", farmId)
+    .eq("produce_id", produceId);
+
+  if (error) throw error;
+}
+
+export async function fetchAllFarmsWithProduce(): Promise<
+  { farm_id: string; produce_ids: string[] }[]
+> {
+  if (!supabase) throw new Error("Supabase is not configured.");
+
+  const { data, error } = await supabase
+    .from("farm_produce")
+    .select("farm_id, produce_id")
+    .eq("is_available", true);
+
+  if (error) throw error;
+
+  const map = new Map<string, string[]>();
+  for (const row of data ?? []) {
+    if (!map.has(row.farm_id)) map.set(row.farm_id, []);
+    map.get(row.farm_id)!.push(row.produce_id);
+  }
+
+  return Array.from(map.entries()).map(([farm_id, produce_ids]) => ({
+    farm_id,
+    produce_ids,
+  }));
+}

--- a/src/providers/cart-provider.tsx
+++ b/src/providers/cart-provider.tsx
@@ -6,6 +6,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import { Alert } from "react-native";
 
 export type CartItem = {
   produce_id: string;
@@ -29,23 +30,35 @@ const CartContext = createContext<CartContextValue | null>(null);
 export function CartProvider({ children }: PropsWithChildren) {
   const [cartItems, setCartItems] = useState<CartItem[]>([]);
 
-  const addItem = useCallback((item: CartItem) => {
-    setCartItems((prev) => {
-      const alreadyInCart = prev.some(
-        (i) => i.produce_id === item.produce_id && i.farm_id === item.farm_id,
-      );
-
-      if (alreadyInCart) {
-        return prev.map((i) =>
-          i.produce_id === item.produce_id && i.farm_id === item.farm_id
-            ? { ...i, qty: i.qty + item.qty }
-            : i,
+  const addItem = useCallback(
+    (item: CartItem) => {
+      const currentFarmId = cartItems[0]?.farm_id;
+      if (currentFarmId && currentFarmId !== item.farm_id) {
+        Alert.alert(
+          "Different farm",
+          "You already have items from another farm in your cart. Please complete or clear that order first.",
         );
+        return;
       }
 
-      return [...prev, item];
-    });
-  }, []);
+      setCartItems((prev) => {
+        const alreadyInCart = prev.some(
+          (i) => i.produce_id === item.produce_id && i.farm_id === item.farm_id,
+        );
+
+        if (alreadyInCart) {
+          return prev.map((i) =>
+            i.produce_id === item.produce_id && i.farm_id === item.farm_id
+              ? { ...i, qty: i.qty + item.qty }
+              : i,
+          );
+        }
+
+        return [...prev, item];
+      });
+    },
+    [cartItems],
+  );
 
   const removeItem = useCallback((produce_id: string) => {
     setCartItems((prev) => prev.filter((i) => i.produce_id !== produce_id));

--- a/src/providers/cart-provider.tsx
+++ b/src/providers/cart-provider.tsx
@@ -10,6 +10,7 @@ import {
 export type CartItem = {
   produce_id: string;
   produce_name: string;
+  farm_id: string;
   qty: number;
   unit: string;
   price_per_unit: number;
@@ -30,11 +31,13 @@ export function CartProvider({ children }: PropsWithChildren) {
 
   const addItem = useCallback((item: CartItem) => {
     setCartItems((prev) => {
-      const alreadyInCart = prev.some((i) => i.produce_id === item.produce_id);
+      const alreadyInCart = prev.some(
+        (i) => i.produce_id === item.produce_id && i.farm_id === item.farm_id,
+      );
 
       if (alreadyInCart) {
         return prev.map((i) =>
-          i.produce_id === item.produce_id
+          i.produce_id === item.produce_id && i.farm_id === item.farm_id
             ? { ...i, qty: i.qty + item.qty }
             : i,
         );

--- a/supabase/functions/decrement-stock/index.ts
+++ b/supabase/functions/decrement-stock/index.ts
@@ -1,0 +1,58 @@
+import { createClient } from "@supabase/supabase-js";
+
+type StockItem = {
+  produce_id: string;
+  qty: number;
+};
+
+Deno.serve(async (req) => {
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { farm_user_id, items } = await req.json();
+
+  if (!farm_user_id || !Array.isArray(items) || items.length === 0) {
+    return Response.json({ error: "Missing required fields" }, { status: 400 });
+  }
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+  );
+
+  const { data: farmProfile, error: farmError } = await supabase
+    .from("farm_profiles")
+    .select("id")
+    .eq("user_id", farm_user_id)
+    .single();
+
+  if (farmError || !farmProfile) {
+    return Response.json({ error: "Farm not found" }, { status: 404 });
+  }
+
+  const farmProfileId = farmProfile.id;
+
+  for (const item of items as StockItem[]) {
+    const { data: stockRow } = await supabase
+      .from("farm_produce")
+      .select("stock")
+      .eq("farm_id", farmProfileId)
+      .eq("produce_id", item.produce_id)
+      .single();
+
+    if (stockRow && stockRow.stock >= item.qty) {
+      await supabase
+        .from("farm_produce")
+        .update({
+          stock: stockRow.stock - item.qty,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("farm_id", farmProfileId)
+        .eq("produce_id", item.produce_id);
+    }
+  }
+
+  return Response.json({ message: "Stock updated" }, { status: 200 });
+});

--- a/tests/farm-profile-screen.test.tsx
+++ b/tests/farm-profile-screen.test.tsx
@@ -18,6 +18,10 @@ jest.mock("../src/providers/auth-provider", () => ({
   }),
 }));
 
+jest.mock("../src/lib/farmProduce", () => ({
+  fetchProduceByFarm: jest.fn().mockResolvedValue([]),
+}));
+
 jest.mock("../src/lib/farmProfiles", () => ({
   deleteFarmProfile: jest.fn(),
   fetchFarmPickupDetailsByFarmerId: (...args: unknown[]) =>


### PR DESCRIPTION
## What's new

this closes #70 

- **Farm stock screen** (`farm/stock.tsx`), farmers can now add, edit, and remove produce from their stock with price and quantity, accessible via a new "Manage Stock" button on the farm profile
- **Farm browser** (`produce/index.tsx`), customers now discover produce by browsing farms instead of a global produce list
- **`farmProduce.ts`**, new library for all `farm_produce` Supabase operations (fetch, upsert, delete)

## What changed

- Cart items now carry a `farm_id`, and deduplication keys on `produce_id + farm_id` so produce from different farms stays separate
- Produce detail screen accepts farm-specific price and unit via nav params
- Checkout derives `farm_id` from the cart instead of a hardcoded mock ID
- Orders now decrement `farm_produce.stock` after a successful purchase or reservation
- Updated farm-screen test
- Added alerts for checkout related to different farms in order

## Known limitations / notes

- When a product's stock reaches 0, customers can still place orders and reservations. Stock is not enforced as a hard gate, it is informational for the farmer. 


### Screenshots
| | |
|---|---|
| <img width="413" height="920" alt="Screenshot 2026-05-04 143439" src="https://github.com/user-attachments/assets/5bc1a8d7-776f-443e-8618-fb7b78d71ce6" /> | <img width="413" height="920" alt="Screenshot 2026-05-04 143515" src="https://github.com/user-attachments/assets/4491e15a-460f-4338-8d6c-ee106fababec" /> |
| <img width="413" height="920" alt="Screenshot 2026-05-04 143637" src="https://github.com/user-attachments/assets/168bb39b-9ab9-407a-9daa-3301b124109d" /> | <img width="412" height="913" alt="Screenshot 2026-05-04 150826" src="https://github.com/user-attachments/assets/36c7acf9-9b33-4a32-becf-09a9db9ff273" /> |