### PR TITLE
feat: Customers can view their order history

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2477,6 +2478,7 @@
       "resolved": "https://registry.npmjs.org/@expo/log-box/-/log-box-55.0.10.tgz",
       "integrity": "sha512-7jdikExgIrCIF5e3P1qMwcUZ2tcxrNdVqE9Y8kNMUHqZ+ipMlin+SiZwJKHM1+am4CYGjhdyrzbnIpvEcLDYcg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@expo/dom-webview": "^55.0.5",
         "anser": "^1.4.9",
@@ -4971,6 +4973,7 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.2.2.tgz",
       "integrity": "sha512-kem1Ko2BcbAjmbQIv66dNmr6EtfDut3QU0qjsVhMnLLhktwyXb6FzZYp8gTrUb6AvkAbaJoi+BF5Pl55pAUa5w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.17.2",
         "escape-string-regexp": "^4.0.0",
@@ -5154,6 +5157,7 @@
       "integrity": "sha512-k6Mjsd9dbZgvY4Bl7P1NIpePQNi+dfYtlJ5voi9KQlynxSyQkfOgJmYGCYmw/aSgH/rUcFvG8u5gd4npzgRDyg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "jest-matcher-utils": "^30.0.5",
         "picocolors": "^1.1.1",
@@ -5347,6 +5351,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5433,6 +5438,7 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -5992,6 +5998,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6810,6 +6817,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -8080,6 +8088,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8276,6 +8285,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8561,6 +8571,7 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-55.0.15.tgz",
       "integrity": "sha512-sHIvqG477UU1jZHhaexXbUgsU7y+xnYZqDW1HrUkEBYiuEb5lobvWLmwea76EBVkityQx46UDtepFtarpUJQqQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "55.0.24",
@@ -8650,6 +8661,7 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.14.tgz",
       "integrity": "sha512-l23QVQCYBPKT5zbxxZdJeuhiunadvWdjcQ9+GC8h+02jCoLmWRk20064nCINnQTP3Hf+uLPteUiwYrJd0e446w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@expo/config": "~55.0.15",
         "@expo/env": "~2.1.1"
@@ -8686,6 +8698,7 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-55.0.6.tgz",
       "integrity": "sha512-x9czUA3UQWjIwa0ZUEs/eWJNqB4mAue/m4ltESlNPLZhHL0nWWqIfsyHmklTLFH7mVfcHSJvew6k+pR2FE1zVw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -8762,6 +8775,7 @@
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-55.0.13.tgz",
       "integrity": "sha512-xbOqNWQCC5RGtXSW83ZCKOjRivyxO2zBouRYy/hgbsyrHUJhztMAjlq8RKYDUL8D6QVsH9Q81SNoq4Zhcn+4HQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "expo-constants": "~55.0.14",
         "invariant": "^2.2.4"
@@ -8909,6 +8923,7 @@
       "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-55.0.7.tgz",
       "integrity": "sha512-Cc1btFyPsD9P4DT2xd1pG/uR96TLVMx0W+dPm9Gjk1uDV9xuzvMcUsY7nf9bt4U5pGyWWkCXmPJcKwWfdl51Pw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.16.0"
       }
@@ -10676,6 +10691,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -14949,6 +14965,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14989,6 +15006,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15025,6 +15043,7 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.83.2.tgz",
       "integrity": "sha512-ZDma3SLkRN2U2dg0/EZqxNBAx4of/oTnPjXAQi299VLq2gdnbZowGy9hzqv+O7sTA62g+lM1v+2FM5DUnJ/6hg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.83.2",
@@ -15083,6 +15102,7 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.30.1.tgz",
       "integrity": "sha512-xIUBDo5ktmJs++0fZlavQNvDEE4PsihWhSeJsJtoz4Q6p0MiTM9TgrTgfEgzRR36qGPytFoeq+ShLrVwGdpUdA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -15167,6 +15187,7 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -15177,6 +15198,7 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.23.0.tgz",
       "integrity": "sha512-XhO3aK0UeLpBn4kLecd+J+EDeRRJlI/Ro9Fze06vo1q163VeYtzfU9QS09/VyDFMWR1qxDC1iazCArTPSFFiPw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
@@ -15203,6 +15225,7 @@
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
       "integrity": "sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
@@ -15235,6 +15258,7 @@
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.7.2.tgz",
       "integrity": "sha512-DuLu1kMV/Uyl9pQHp3hehAlThoLw7Yk2FwRTpzASOmI+cd4845FWn3m2bk9MnjUw8FBRIyhwLqYm2AJaXDXsog==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "7.27.1",
         "@babel/plugin-transform-class-properties": "7.27.1",
@@ -15491,6 +15515,7 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15570,6 +15595,7 @@
       "integrity": "sha512-zLCFMHFE9vy/w3AxO0zNxy6aAupnCuLSVOJYDe/Tp+ayGI1f2PLQsFVPANSD42gdSbmYx5oN+1VWDhcXtq7hAQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-is": "^19.2.0",
         "scheduler": "^0.27.0"
@@ -17224,6 +17250,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2478,7 +2477,6 @@
       "resolved": "https://registry.npmjs.org/@expo/log-box/-/log-box-55.0.10.tgz",
       "integrity": "sha512-7jdikExgIrCIF5e3P1qMwcUZ2tcxrNdVqE9Y8kNMUHqZ+ipMlin+SiZwJKHM1+am4CYGjhdyrzbnIpvEcLDYcg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@expo/dom-webview": "^55.0.5",
         "anser": "^1.4.9",
@@ -4973,7 +4971,6 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.2.2.tgz",
       "integrity": "sha512-kem1Ko2BcbAjmbQIv66dNmr6EtfDut3QU0qjsVhMnLLhktwyXb6FzZYp8gTrUb6AvkAbaJoi+BF5Pl55pAUa5w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.17.2",
         "escape-string-regexp": "^4.0.0",
@@ -5157,7 +5154,6 @@
       "integrity": "sha512-k6Mjsd9dbZgvY4Bl7P1NIpePQNi+dfYtlJ5voi9KQlynxSyQkfOgJmYGCYmw/aSgH/rUcFvG8u5gd4npzgRDyg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "jest-matcher-utils": "^30.0.5",
         "picocolors": "^1.1.1",
@@ -5351,7 +5347,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5438,7 +5433,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -5998,7 +5992,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6817,7 +6810,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -8088,7 +8080,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8285,7 +8276,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8571,7 +8561,6 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-55.0.15.tgz",
       "integrity": "sha512-sHIvqG477UU1jZHhaexXbUgsU7y+xnYZqDW1HrUkEBYiuEb5lobvWLmwea76EBVkityQx46UDtepFtarpUJQqQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "55.0.24",
@@ -8661,7 +8650,6 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.14.tgz",
       "integrity": "sha512-l23QVQCYBPKT5zbxxZdJeuhiunadvWdjcQ9+GC8h+02jCoLmWRk20064nCINnQTP3Hf+uLPteUiwYrJd0e446w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@expo/config": "~55.0.15",
         "@expo/env": "~2.1.1"
@@ -8698,7 +8686,6 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-55.0.6.tgz",
       "integrity": "sha512-x9czUA3UQWjIwa0ZUEs/eWJNqB4mAue/m4ltESlNPLZhHL0nWWqIfsyHmklTLFH7mVfcHSJvew6k+pR2FE1zVw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -8775,7 +8762,6 @@
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-55.0.13.tgz",
       "integrity": "sha512-xbOqNWQCC5RGtXSW83ZCKOjRivyxO2zBouRYy/hgbsyrHUJhztMAjlq8RKYDUL8D6QVsH9Q81SNoq4Zhcn+4HQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "expo-constants": "~55.0.14",
         "invariant": "^2.2.4"
@@ -8923,7 +8909,6 @@
       "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-55.0.7.tgz",
       "integrity": "sha512-Cc1btFyPsD9P4DT2xd1pG/uR96TLVMx0W+dPm9Gjk1uDV9xuzvMcUsY7nf9bt4U5pGyWWkCXmPJcKwWfdl51Pw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.16.0"
       }
@@ -10691,7 +10676,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -14965,7 +14949,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15006,7 +14989,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15043,7 +15025,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.83.2.tgz",
       "integrity": "sha512-ZDma3SLkRN2U2dg0/EZqxNBAx4of/oTnPjXAQi299VLq2gdnbZowGy9hzqv+O7sTA62g+lM1v+2FM5DUnJ/6hg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.83.2",
@@ -15102,7 +15083,6 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.30.1.tgz",
       "integrity": "sha512-xIUBDo5ktmJs++0fZlavQNvDEE4PsihWhSeJsJtoz4Q6p0MiTM9TgrTgfEgzRR36qGPytFoeq+ShLrVwGdpUdA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -15187,7 +15167,6 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -15198,7 +15177,6 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.23.0.tgz",
       "integrity": "sha512-XhO3aK0UeLpBn4kLecd+J+EDeRRJlI/Ro9Fze06vo1q163VeYtzfU9QS09/VyDFMWR1qxDC1iazCArTPSFFiPw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
@@ -15225,7 +15203,6 @@
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
       "integrity": "sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
@@ -15258,7 +15235,6 @@
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.7.2.tgz",
       "integrity": "sha512-DuLu1kMV/Uyl9pQHp3hehAlThoLw7Yk2FwRTpzASOmI+cd4845FWn3m2bk9MnjUw8FBRIyhwLqYm2AJaXDXsog==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "7.27.1",
         "@babel/plugin-transform-class-properties": "7.27.1",
@@ -15515,7 +15491,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15595,7 +15570,6 @@
       "integrity": "sha512-zLCFMHFE9vy/w3AxO0zNxy6aAupnCuLSVOJYDe/Tp+ayGI1f2PLQsFVPANSD42gdSbmYx5oN+1VWDhcXtq7hAQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-is": "^19.2.0",
         "scheduler": "^0.27.0"
@@ -17250,7 +17224,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/app/account.tsx
+++ b/src/app/account.tsx
@@ -513,6 +513,23 @@ export default function AccountScreen() {
           <Text style={styles.successText}>{successMessage}</Text>
         ) : null}
 
+        {profile?.role === "customer" ? (
+          <View style={styles.panel}>
+            <Text style={styles.panelTitle}>Order history</Text>
+            <Text style={styles.panelBody}>
+              View your past purchases and pickup reservations.
+            </Text>
+            <Link href={"/order-history" as Href} asChild>
+              <Pressable
+                accessibilityRole="button"
+                style={styles.primaryButton}
+              >
+                <Text style={styles.primaryButtonText}>View order history</Text>
+              </Pressable>
+            </Link>
+          </View>
+        ) : null}
+
         <View style={styles.bottomRow}>
           <Pressable
             accessibilityRole="button"

--- a/src/app/order-history.tsx
+++ b/src/app/order-history.tsx
@@ -52,12 +52,16 @@ function OrderCard({ order }: { order: OrderWithItems }) {
         </View>
         <View style={styles.metaItem}>
           <Text style={styles.metaLabel}>Placed</Text>
-          <Text style={styles.metaValue}>{formatTimestamp(order.created_at)}</Text>
+          <Text style={styles.metaValue}>
+            {formatTimestamp(order.created_at)}
+          </Text>
         </View>
         {order.expires_at ? (
           <View style={styles.metaItem}>
             <Text style={styles.metaLabel}>Expires</Text>
-            <Text style={styles.metaValue}>{formatTimestamp(order.expires_at)}</Text>
+            <Text style={styles.metaValue}>
+              {formatTimestamp(order.expires_at)}
+            </Text>
           </View>
         ) : null}
       </View>

--- a/src/app/order-history.tsx
+++ b/src/app/order-history.tsx
@@ -1,0 +1,325 @@
+import { useRouter } from "expo-router";
+import { useEffect, useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import {
+  fetchOrderItems,
+  fetchOrdersByCustomer,
+  type Order,
+  type OrderItem,
+} from "../lib/checkout/order";
+import { useAuth } from "../providers/auth-provider";
+
+function formatTimestamp(value: string | null | undefined) {
+  if (!value) return "Unavailable";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "Unavailable";
+  return parsed.toLocaleString("en-GB", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function OrderCard({ order }: { order: Order }) {
+  const isPickup = order.delivery_method === "pickup";
+  const [items, setItems] = useState<OrderItem[]>([]);
+
+  useEffect(() => {
+    fetchOrderItems(order.id)
+      .then(setItems)
+      .catch(() => {});
+  }, [order.id]);
+
+  return (
+    <View style={styles.orderCard}>
+      <View style={styles.orderHeading}>
+        <Text style={styles.orderTitle}>Order #{order.id.slice(0, 8)}</Text>
+        <Text style={styles.orderValue}>{order.total_price} kr</Text>
+      </View>
+
+      <View style={styles.divider} />
+
+      <View style={styles.metaGrid}>
+        <View style={styles.metaItem}>
+          <Text style={styles.metaLabel}>Status</Text>
+          <Text style={styles.metaValue}>{order.status}</Text>
+        </View>
+        <View style={styles.metaItem}>
+          <Text style={styles.metaLabel}>Delivery</Text>
+          <Text style={styles.metaValue}>{order.delivery_method}</Text>
+        </View>
+        <View style={styles.metaItem}>
+          <Text style={styles.metaLabel}>Placed</Text>
+          <Text style={styles.metaValue}>
+            {formatTimestamp(order.created_at)}
+          </Text>
+        </View>
+        {order.expires_at ? (
+          <View style={styles.metaItem}>
+            <Text style={styles.metaLabel}>Expires</Text>
+            <Text style={styles.metaValue}>
+              {formatTimestamp(order.expires_at)}
+            </Text>
+          </View>
+        ) : null}
+      </View>
+
+      {isPickup && order.pickup_notes ? (
+        <View style={styles.notesBlock}>
+          <Text style={styles.metaLabel}>Pickup notes</Text>
+          <Text style={styles.notesValue}>{order.pickup_notes}</Text>
+        </View>
+      ) : null}
+
+      {items.length > 0 ? (
+        <View style={styles.itemsBlock}>
+          <Text style={styles.metaLabel}>Items</Text>
+          {items.map((item) => (
+            <View key={item.id} style={styles.itemRow}>
+              <Text style={styles.itemName}>{item.produce_name}</Text>
+              <Text style={styles.itemDetail}>
+                {item.qty} {item.unit} · {item.price} kr
+              </Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+export default function OrderHistoryScreen() {
+  const { user } = useAuth();
+  const router = useRouter();
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function loadOrders() {
+      if (!user?.id) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await fetchOrdersByCustomer(user.id);
+        setOrders(result);
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "Unable to load order history.",
+        );
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadOrders();
+  }, [user?.id]);
+
+  return (
+    <SafeAreaView style={styles.page}>
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={styles.header}>
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => router.back()}
+            style={styles.backButton}
+          >
+            <Text style={styles.backButtonText}>← Back</Text>
+          </Pressable>
+          <Text style={styles.screenTitle}>Order history</Text>
+          <Text style={styles.screenBody}>
+            Your past purchases and pickup reservations from FarmConnect.
+          </Text>
+        </View>
+
+        {loading ? (
+          <View style={styles.statePanel}>
+            <ActivityIndicator color="#2F6A3E" />
+            <Text style={styles.stateText}>Loading orders...</Text>
+          </View>
+        ) : error ? (
+          <View style={styles.statePanel}>
+            <Text style={styles.errorText}>{error}</Text>
+          </View>
+        ) : orders.length === 0 ? (
+          <View style={styles.statePanel}>
+            <Text style={styles.stateText}>No orders yet.</Text>
+            <Text style={styles.stateBody}>
+              Place an order from the checkout screen to see it here.
+            </Text>
+          </View>
+        ) : (
+          orders.map((order) => <OrderCard key={order.id} order={order} />)
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const shadow = {
+  boxShadow: "0px 18px 40px rgba(26, 41, 30, 0.08)",
+} as const;
+
+const styles = StyleSheet.create({
+  page: {
+    flex: 1,
+    backgroundColor: "#F4F5EF",
+  },
+  scrollContent: {
+    gap: 16,
+    paddingHorizontal: 18,
+    paddingVertical: 24,
+  },
+  header: {
+    gap: 6,
+  },
+  backButton: {
+    alignSelf: "flex-start",
+    backgroundColor: "#EEF5EB",
+    borderRadius: 999,
+    paddingHorizontal: 14,
+    paddingVertical: 9,
+    marginBottom: 6,
+  },
+  backButtonText: {
+    color: "#214C2D",
+    fontSize: 13,
+    fontWeight: "700",
+  },
+  screenTitle: {
+    color: "#182019",
+    fontSize: 26,
+    fontWeight: "800",
+    letterSpacing: -0.5,
+  },
+  screenBody: {
+    color: "#5D6A60",
+    fontSize: 14,
+    lineHeight: 21,
+  },
+  orderCard: {
+    backgroundColor: "#FFFFFF",
+    borderColor: "#DFE4DB",
+    borderRadius: 24,
+    borderWidth: 1,
+    gap: 12,
+    padding: 18,
+    ...shadow,
+  },
+  orderHeading: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  orderTitle: {
+    color: "#182019",
+    fontSize: 16,
+    fontWeight: "800",
+  },
+  orderValue: {
+    color: "#21432D",
+    fontSize: 16,
+    fontWeight: "800",
+  },
+  divider: {
+    height: 1,
+    backgroundColor: "#EDF1EB",
+  },
+  metaGrid: {
+    gap: 8,
+  },
+  metaItem: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  metaLabel: {
+    color: "#5D6A60",
+    fontSize: 12,
+    fontWeight: "700",
+    textTransform: "uppercase",
+    letterSpacing: 0.3,
+  },
+  metaValue: {
+    color: "#445148",
+    fontSize: 14,
+  },
+  notesBlock: {
+    backgroundColor: "#F7FBF5",
+    borderColor: "#D7E2D3",
+    borderRadius: 14,
+    borderWidth: 1,
+    gap: 4,
+    padding: 12,
+  },
+  notesValue: {
+    color: "#213025",
+    fontSize: 14,
+    lineHeight: 20,
+    marginTop: 4,
+  },
+  itemsBlock: {
+    gap: 8,
+  },
+  itemRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    backgroundColor: "#F7FBF5",
+    borderColor: "#D7E2D3",
+    borderRadius: 12,
+    borderWidth: 1,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  itemName: {
+    color: "#182019",
+    fontSize: 14,
+    fontWeight: "700",
+    flexShrink: 1,
+  },
+  itemDetail: {
+    color: "#445148",
+    fontSize: 13,
+    marginLeft: 8,
+  },
+  statePanel: {
+    backgroundColor: "#FFFFFF",
+    borderColor: "#DFE4DB",
+    borderRadius: 24,
+    borderWidth: 1,
+    alignItems: "center",
+    gap: 8,
+    padding: 24,
+    ...shadow,
+  },
+  stateText: {
+    color: "#182019",
+    fontSize: 16,
+    fontWeight: "700",
+  },
+  stateBody: {
+    color: "#5D6A60",
+    fontSize: 14,
+    lineHeight: 21,
+    textAlign: "center",
+  },
+  errorText: {
+    color: "#9C5B4D",
+    fontSize: 14,
+    lineHeight: 20,
+  },
+});

--- a/src/app/order-history.tsx
+++ b/src/app/order-history.tsx
@@ -11,10 +11,8 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import {
-  fetchOrderItems,
-  fetchOrdersByCustomer,
-  type Order,
-  type OrderItem,
+  fetchOrdersWithItems,
+  type OrderWithItems,
 } from "../lib/checkout/order";
 import { useAuth } from "../providers/auth-provider";
 
@@ -31,15 +29,8 @@ function formatTimestamp(value: string | null | undefined) {
   });
 }
 
-function OrderCard({ order }: { order: Order }) {
+function OrderCard({ order }: { order: OrderWithItems }) {
   const isPickup = order.delivery_method === "pickup";
-  const [items, setItems] = useState<OrderItem[]>([]);
-
-  useEffect(() => {
-    fetchOrderItems(order.id)
-      .then(setItems)
-      .catch(() => {});
-  }, [order.id]);
 
   return (
     <View style={styles.orderCard}>
@@ -61,16 +52,12 @@ function OrderCard({ order }: { order: Order }) {
         </View>
         <View style={styles.metaItem}>
           <Text style={styles.metaLabel}>Placed</Text>
-          <Text style={styles.metaValue}>
-            {formatTimestamp(order.created_at)}
-          </Text>
+          <Text style={styles.metaValue}>{formatTimestamp(order.created_at)}</Text>
         </View>
         {order.expires_at ? (
           <View style={styles.metaItem}>
             <Text style={styles.metaLabel}>Expires</Text>
-            <Text style={styles.metaValue}>
-              {formatTimestamp(order.expires_at)}
-            </Text>
+            <Text style={styles.metaValue}>{formatTimestamp(order.expires_at)}</Text>
           </View>
         ) : null}
       </View>
@@ -82,10 +69,10 @@ function OrderCard({ order }: { order: Order }) {
         </View>
       ) : null}
 
-      {items.length > 0 ? (
+      {order.items.length > 0 ? (
         <View style={styles.itemsBlock}>
           <Text style={styles.metaLabel}>Items</Text>
-          {items.map((item) => (
+          {order.items.map((item) => (
             <View key={item.id} style={styles.itemRow}>
               <Text style={styles.itemName}>{item.produce_name}</Text>
               <Text style={styles.itemDetail}>
@@ -101,7 +88,7 @@ function OrderCard({ order }: { order: Order }) {
 export default function OrderHistoryScreen() {
   const { user } = useAuth();
   const router = useRouter();
-  const [orders, setOrders] = useState<Order[]>([]);
+  const [orders, setOrders] = useState<OrderWithItems[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -111,7 +98,7 @@ export default function OrderHistoryScreen() {
       setLoading(true);
       setError(null);
       try {
-        const result = await fetchOrdersByCustomer(user.id);
+        const result = await fetchOrdersWithItems(user.id);
         setOrders(result);
       } catch (err) {
         setError(

--- a/src/lib/checkout/order.ts
+++ b/src/lib/checkout/order.ts
@@ -25,6 +25,10 @@ export type OrderItem = {
   price: number;
 };
 
+export type OrderWithItems = Order & { 
+  items: OrderItem[] 
+};
+
 export type CreateOrderInput = {
   customer_id: string;
   farm_id: string;
@@ -113,6 +117,30 @@ export async function fetchOrderItems(orderId: string): Promise<OrderItem[]> {
   return data ?? [];
 }
 
+export async function fetchOrdersWithItems(customerId: string): Promise<OrderWithItems[]> {
+  if (!supabase) throw new Error("Supabase is not configured.");
+  const { data: orders, error: ordersError } = await supabase
+    .from("orders")
+    .select("*")
+    .eq("customer_id", customerId)
+    .order("created_at", { ascending: false });
+
+  if (ordersError) throw ordersError;
+  if (!orders || orders.length === 0) return [];
+
+  const { data: items, error: itemsError } = await supabase
+    .from("order_items")
+    .select("*")
+    .in("order_id", orders.map((o) => o.id));
+
+  if (ordersError) throw ordersError;
+
+  return orders.map((order) => ({
+    ...order,
+    items: (items ?? []).filter((item) => item.order_id === order.id),
+  }));
+}
+
 export async function updateOrderStatus(
   orderId: string,
   status: OrderStatus,
@@ -126,3 +154,4 @@ export async function updateOrderStatus(
 
   if (error) throw error;
 }
+

--- a/src/lib/checkout/order.ts
+++ b/src/lib/checkout/order.ts
@@ -25,8 +25,8 @@ export type OrderItem = {
   price: number;
 };
 
-export type OrderWithItems = Order & { 
-  items: OrderItem[] 
+export type OrderWithItems = Order & {
+  items: OrderItem[];
 };
 
 export type CreateOrderInput = {
@@ -117,7 +117,9 @@ export async function fetchOrderItems(orderId: string): Promise<OrderItem[]> {
   return data ?? [];
 }
 
-export async function fetchOrdersWithItems(customerId: string): Promise<OrderWithItems[]> {
+export async function fetchOrdersWithItems(
+  customerId: string,
+): Promise<OrderWithItems[]> {
   if (!supabase) throw new Error("Supabase is not configured.");
   const { data: orders, error: ordersError } = await supabase
     .from("orders")
@@ -131,9 +133,12 @@ export async function fetchOrdersWithItems(customerId: string): Promise<OrderWit
   const { data: items, error: itemsError } = await supabase
     .from("order_items")
     .select("*")
-    .in("order_id", orders.map((o) => o.id));
+    .in(
+      "order_id",
+      orders.map((o) => o.id),
+    );
 
-  if (ordersError) throw ordersError;
+  if (itemsError) throw itemsError;
 
   return orders.map((order) => ({
     ...order,
@@ -154,4 +159,3 @@ export async function updateOrderStatus(
 
   if (error) throw error;
 }
-


### PR DESCRIPTION
Completes #92 

Adds a dedicated order history screen for customers, accessible from the account page

**Changes**
app/account.tsx — new button for customer profile that redirects the user to the order-history screen. 

app/order-history.tsx — standalone screen showing a customer's past orders, including status, delivery method, placement time, expiry, pickup notes, and itemised produce list per order

<img width="382" height="887" alt="image" src="https://github.com/user-attachments/assets/be14f90b-2869-426f-8144-96d6c29fb031" />

<img width="380" height="885" alt="image" src="https://github.com/user-attachments/assets/b8209230-e05c-492b-9fcb-26282f5ea778" />
