### PR TITLE
fix demo seed password hashing

### DIFF
--- a/supabase/migrations/202605111200_seed_full_demo_data.sql
+++ b/supabase/migrations/202605111200_seed_full_demo_data.sql
@@ -207,7 +207,7 @@ select
   'authenticated',
   'authenticated',
   email,
-  crypt(password, gen_salt('bf')),
+  extensions.crypt(password, extensions.gen_salt('bf')),
   now(),
   '{"provider": "email", "providers": ["email"]}'::jsonb,
   jsonb_build_object('full_name', full_name, 'role', role),


### PR DESCRIPTION
Fixes the demo seed migration failure when Supabase resolves `pgcrypto` functions from the `extensions` schema.

The migration now schema-qualifies `crypt` and `gen_salt`, so the demo user passwords can be hashed during `db push`.